### PR TITLE
Remove external template dependencies (Aeon.Acquisition, aind-behavior-services)

### DIFF
--- a/template/template/.bonsai/Bonsai.config.jinja
+++ b/template/template/.bonsai/Bonsai.config.jinja
@@ -1,7 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageConfiguration xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Packages>
-    <Package id="Aeon.Acquisition" version="0.6.0" />
     <Package id="AllenNeuralDynamics.LicketySplit" version="0.2.0" />
     <Package id="AsyncIO" version="0.1.69" />
     <Package id="Bonsai" version="2.9.0" />
@@ -62,7 +61,6 @@
     <Package id="YamlDotNet" version="16.3.0" />
   </Packages>
   <AssemblyReferences>
-    <AssemblyReference assemblyName="Aeon.Acquisition" />
     <AssemblyReference assemblyName="AllenNeuralDynamics.LicketySplit" />
     <AssemblyReference assemblyName="Bonsai" />
     <AssemblyReference assemblyName="Bonsai.Arduino" />
@@ -93,7 +91,6 @@
     <AssemblyReference assemblyName="UclOpen.Video" />
   </AssemblyReferences>
   <AssemblyLocations>
-    <AssemblyLocation assemblyName="Aeon.Acquisition" processorArchitecture="MSIL" location="Packages/Aeon.Acquisition.0.6.0/lib/net472/Aeon.Acquisition.dll" />
     <AssemblyLocation assemblyName="AllenNeuralDynamics.LicketySplit" processorArchitecture="MSIL" location="Packages/AllenNeuralDynamics.LicketySplit.0.2.0/lib/net462/AllenNeuralDynamics.LicketySplit.dll" />
     <AssemblyLocation assemblyName="AsyncIO" processorArchitecture="MSIL" location="Packages/AsyncIO.0.1.69/lib/net40/AsyncIO.dll" />
     <AssemblyLocation assemblyName="Basler.Pylon" processorArchitecture="X86" location="Packages/Bonsai.Pylon.0.3.0/build/net462/bin/x86/Basler.Pylon.dll" />

--- a/template/template/pyproject.toml.jinja
+++ b/template/template/pyproject.toml.jinja
@@ -28,6 +28,7 @@ dependencies = [
 # Changelog = "https://github.com/UclOpen/{{ dotnet_full_name }}/releases"
 [project.scripts]
 {{ project_name }} = "{{ python_folder_name }}.cli:main"
+regenerate-schemas = "{{ python_folder_name }}.regenerate:main"
 
 [tool.ruff]
 line-length = 120

--- a/template/template/scripts/deploy.ps1
+++ b/template/template/scripts/deploy.ps1
@@ -5,38 +5,42 @@ Set-Location (Split-Path -Parent $scriptDirectory)
 Write-Output "Initializing and updating submodules..."
 &git submodule update --init --recursive
 
-Write-Output "Creating a Python  environment..."
-
 if (-not (Get-Command uv -ErrorAction SilentlyContinue)) {
     throw "The 'uv' command was not found. See https://docs.astral.sh/uv/getting-started/installation/ for instructions."
 }
 
+Write-Output "Creating a Python environment..."
 if (Test-Path -Path ./.venv) {
     Remove-Item ./.venv -Recurse -Force
 }
 &uv venv
 .\.venv\Scripts\Activate.ps1
 Write-Output "Synchronizing environment..."
-&uv sync 
+&uv sync
 
-Write-Output "Creating a Bonsai environment and installing packages..."
-if (Test-Path -Path "bonsai") {
-    Set-Location "bonsai"
-    .\setup.ps1
-} elseif (Test-Path -Path ".bonsai") {
-    Set-Location ".bonsai"
-    .\setup.ps1
-} else {
-    throw "Neither 'bonsai' nor '.bonsai' directory found."
-}
-Set-Location ..
+Write-Output "Regenerating JSON schema from pydantic models..."
+&uv run regenerate-schemas
 
-if (-not (Test-Path -Path src\Extensions)) {
-    Write-Output "Creating bonsai extensions folder..."
-    New-Item -ItemType Directory -Path src\Extensions | Out-Null
+if (-not (Get-Command dotnet -ErrorAction SilentlyContinue)) {
+    throw "The 'dotnet' command was not found. Install the .NET SDK: https://dotnet.microsoft.com/download"
 }
+
+Write-Output "Restoring dotnet tools..."
+&dotnet tool restore
+
+# Derive C# namespace from schema filename (snake_case -> PascalCase).
+$schemaFile = Get-ChildItem ".\src\DataSchemas\*.json" | Select-Object -First 1
+if (-not $schemaFile) { throw "No JSON schema found in .\src\DataSchemas\. Run 'uv run regenerate-schemas' first." }
+$namespace = ($schemaFile.BaseName -split "_" | ForEach-Object { $_.Substring(0,1).ToUpper() + $_.Substring(1) }) -join ""
+
+Write-Output "Generating C# classes (namespace: $namespace, serializers: json yaml)..."
+Push-Location .\src\Extensions
+&dotnet bonsai.sgen $schemaFile.FullName --namespace $namespace --serializer json --serializer yaml
+Pop-Location
 
 if (-not (Test-Path -Path src\DataSchemas)) {
-    Write-Output "Creating sgen output folder..."
     New-Item -ItemType Directory -Path src\DataSchemas | Out-Null
+}
+if (-not (Test-Path -Path src\Extensions)) {
+    New-Item -ItemType Directory -Path src\Extensions | Out-Null
 }

--- a/template/template/src/{{ python_folder_name }}/regenerate.py.jinja
+++ b/template/template/src/{{ python_folder_name }}/regenerate.py.jinja
@@ -1,16 +1,13 @@
 from pathlib import Path
 from typing import Union
-
+import json
 import pydantic
-from ucl_open.rigs.experiment import Experiment
-from aind_behavior_services.utils import BonsaiSgenSerializers, convert_pydantic_to_bonsai
 
 import {{ python_folder_name }}.rig
 import {{ python_folder_name }}.task
 
 SCHEMA_ROOT = Path("./src/DataSchemas/")
-EXTENSIONS_ROOT = Path("./src/Extensions/")
-NAMESPACE_PREFIX = "{{ python_class_prefix }}DataSchema"
+SCHEMA_FILE = SCHEMA_ROOT / "{{ python_folder_name }}.json"
 
 
 def main():
@@ -19,16 +16,10 @@ def main():
         {{ python_folder_name }}.rig.{{ python_class_prefix }}Rig,
     ]
     model = pydantic.RootModel[Union[tuple(models)]]
-
-    convert_pydantic_to_bonsai(
-        model, # type: ignore
-        model_name="{{ python_folder_name }}",
-        root_element="Root",
-        cs_namespace=NAMESPACE_PREFIX,
-        json_schema_output_dir=SCHEMA_ROOT,
-        cs_output_dir=EXTENSIONS_ROOT,
-        cs_serializer=[BonsaiSgenSerializers.JSON],
-    )
+    schema = model.model_json_schema(by_alias=True, mode="serialization", union_format="primitive_type_array")
+    SCHEMA_ROOT.mkdir(parents=True, exist_ok=True)
+    SCHEMA_FILE.write_text(json.dumps(schema, indent=2))
+    print(f"Schema written to {SCHEMA_FILE}")
 
 
 if __name__ == "__main__":

--- a/template/template/src/{{ python_folder_name }}/rig.py.jinja
+++ b/template/template/src/{{ python_folder_name }}/rig.py.jinja
@@ -1,12 +1,11 @@
 from typing import Literal, Dict
 from pydantic import Field
 
-from ucl_open.rigs.base import BaseSchema
-import ucl_open.rigs.device as Device
+from ucl_open.core.rig import Rig
 
 from {{ python_folder_name }} import __semver__
 
 
-class {{ python_class_prefix }}Rig(BaseSchema):
+class {{ python_class_prefix }}Rig(Rig):
     version: Literal[__semver__] = __semver__
     ...


### PR DESCRIPTION
Removes two third-party dependencies from the Copier template that new experiment repos should not need.

Aeon.Acquisition - removed from Bonsai.config.jinja.
aind-behavior-services - removed from regenerate.py.jinja and deploy.ps1. The convert_pydantic_to_bonsai helper from that package is replaced by a direct model_json_schema export, with dotnet bonsai.sgen called explicitly in deploy.ps1 to generate C# classes. Many of the issues that the AIND script was solving has been folded into Bonsai.sgen