### PR TITLE
Add HarpTimestampGeneratorGen3 schema, workflow, and docs

### DIFF
--- a/docs/articles/devices/harp-timestamp-generator-gen3.md
+++ b/docs/articles/devices/harp-timestamp-generator-gen3.md
@@ -1,0 +1,81 @@
+# Harp Timestamp Generator Gen3
+
+The Harp Timestamp Generator Gen3 (`who_am_i = 1158`) is a hardware clock synchroniser for Harp networks. It broadcasts a shared hardware timestamp over audio jack cables, allowing all devices on the rig to record data against a common timebase rather than relying on the PC system clock.
+
+---
+
+## Python schema
+
+`HarpTimestampGeneratorGen3` is defined in `ucl_open.devices` with the following fields:
+
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `port_name` | `str` | - | Serial port the device is connected to (e.g. `COM3`) |
+| `timer_frequency` | `TimerFrequency` | `Timer1000Hz` | Rate at which timestamp events are sent to Bonsai |
+
+`TimerFrequency` is used to set the rate at which clock events are generated in Bonsai: `Disabled`, `Timer50Hz`, `Timer100Hz`, `Timer200Hz`, `Timer500Hz`, `Timer1000Hz`. These can then be used as the timestamps for the rest of your workflow. 
+
+### Configuration example
+
+In your `rig.py`:
+
+```python
+from ucl_open.devices import HarpTimestampGeneratorGen3, TimerFrequency
+
+timestamp_generator: HarpTimestampGeneratorGen3 = HarpTimestampGeneratorGen3(
+    port_name="COM3",
+    timer_frequency=TimerFrequency.Timer1000Hz,
+)
+```
+
+Or as YAML:
+
+```yaml
+timestamp_generator:
+  port_name: COM3
+  timer_frequency: Timer1000Hz
+```
+
+---
+
+## Bonsai workflow
+
+:::workflow
+![TimestampGeneratorGen3](~/assets/workflows/TimestampGeneratorGen3.bonsai)
+:::
+
+The workflow has three logical sections.
+
+### 1. Initialization sequence
+
+On startup the workflow synchronizes the PC clock to the Harp hardware clock (`SynchronizeTimestamp`), waits for that to complete (`Take(1)`), then sends a write command to configure the timer frequency after a 100 ms delay. `Concat` sequences these two messages so the timer is only configured after synchronization and we do not risk concurrent write messages clashing at the same time. Depending on how hardware is configured, timestamps before 100ms may be incorrect or at an incorrect frequency.
+
+### 2. Device and event bus
+
+The `Device` node opens the serial connection to the Timestamp Generator. It receives the initialization messages from the `Concat` sequence and emits all incoming Harp messages as an output stream. These are immediately published to a named `PublishSubject` (`ClockSynchronizerEvents` by default, overridable via `EventsSubjectName`). A subscription to this subject allows access to these events elsewhere in the workflow.
+
+Three device properties are externalized so they can be set from the rig configuration: `PortName` intended to be set from configuraion yaml, and `DumpRegisters`, and `Heartbeat` set in the workflow.
+
+### 3. Timestamps group
+
+The `Timestamps` nested workflow subscribes to the same events subject and derives two outputs:
+
+:::workflow
+![TimestampGeneratorGen3 Timestamps](~/assets/workflows/TimestampGeneratorGen3_Timestamps.bonsai)
+:::
+
+- **`Heartbeats` subject** - the raw once-per-second `TimestampSeconds` event stream, useful for monitoring clock health and sychronization across devices.
+- **`Timebase` subject** - the running time since the workflow was started. The `Timer` register is parsed on every event; the first value is captured with `Take(1)` and held as the reference point. `WithLatestFrom` pairs each subsequent timer value with that reference, and `Subtract` computes the elapsed time since start. 
+
+---
+
+## Using the timebase in other modules
+
+To stamp data from a non-Harp device with the hardware clock, subscribe to the `Timestamp` subject from the `Timestamps` group and use `WithLatestFrom`:
+
+```
+[Your data stream] ──→ WithLatestFrom ──→ [Timestamped data]
+                              ↑
+                        Timestamp (BehaviorSubject)
+```

--- a/docs/articles/toc.yml
+++ b/docs/articles/toc.yml
@@ -6,3 +6,7 @@
   href: contributing.md
 - name: Project Structure
   href: project-structure.md
+- name: Devices
+  items:
+  - name: Harp Timestamp Generator Gen3
+    href: devices/harp-timestamp-generator-gen3.md

--- a/docs/assets/workflows/TimestampGeneratorGen3.bonsai
+++ b/docs/assets/workflows/TimestampGeneratorGen3.bonsai
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="utf-8"?>
+<WorkflowBuilder Version="2.9.0"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xmlns:harp="clr-namespace:Bonsai.Harp;assembly=Bonsai.Harp"
+                 xmlns:rx="clr-namespace:Bonsai.Reactive;assembly=Bonsai.Core"
+                 xmlns:p1="clr-namespace:Harp.TimestampGeneratorGen3;assembly=Harp.TimestampGeneratorGen3"
+                 xmlns="https://bonsai-rx.org/2018/workflow">
+  <Workflow>
+    <Nodes>
+      <Expression xsi:type="Unit" />
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="harp:SynchronizeTimestamp" />
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="rx:Take">
+          <rx:Count>1</rx:Count>
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="ExternalizedMapping">
+        <Property Name="TimerFrequency" Description="The frequency at which to send timestamp events to Bonsai" />
+      </Expression>
+      <Expression xsi:type="p1:CreateMessage">
+        <harp:MessageType>Write</harp:MessageType>
+        <harp:Payload xsi:type="p1:CreateTimerFrequencyPayload">
+          <p1:TimerFrequency>Timer1000Hz</p1:TimerFrequency>
+        </harp:Payload>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="rx:Delay">
+          <rx:DueTime>PT0.1S</rx:DueTime>
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="rx:Concat" />
+      </Expression>
+      <Expression xsi:type="ExternalizedMapping">
+        <Property Name="PortName" />
+        <Property Name="DumpRegisters" />
+        <Property Name="Heartbeat" />
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="p1:Device">
+          <harp:OperationMode>Active</harp:OperationMode>
+          <harp:OperationLed>On</harp:OperationLed>
+          <harp:DumpRegisters>true</harp:DumpRegisters>
+          <harp:VisualIndicators>On</harp:VisualIndicators>
+          <harp:Heartbeat>Enabled</harp:Heartbeat>
+          <harp:IgnoreErrors>false</harp:IgnoreErrors>
+          <harp:PortName>COMx</harp:PortName>
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="ExternalizedMapping">
+        <Property Name="Name" DisplayName="EventsSubjectName" Description="The name of the output &quot;Events&quot; Subject" />
+      </Expression>
+      <Expression xsi:type="rx:PublishSubject">
+        <Name>ClockSynchronizerEvents</Name>
+      </Expression>
+      <Expression xsi:type="WorkflowOutput" />
+      <Expression xsi:type="GroupWorkflow">
+        <Name>Timestamps</Name>
+        <Workflow>
+          <Nodes>
+            <Expression xsi:type="ExternalizedMapping">
+              <Property Name="Name" />
+            </Expression>
+            <Expression xsi:type="SubscribeSubject">
+              <Name>ClockSynchronizerEvents</Name>
+            </Expression>
+            <Expression xsi:type="Combinator">
+              <Combinator xsi:type="harp:FilterMessageType">
+                <harp:FilterType>Include</harp:FilterType>
+                <harp:MessageType>Event</harp:MessageType>
+              </Combinator>
+            </Expression>
+            <Expression xsi:type="harp:FilterRegister">
+              <harp:FilterType>Include</harp:FilterType>
+              <harp:Register xsi:type="harp:TimestampSeconds" />
+            </Expression>
+            <Expression xsi:type="rx:PublishSubject">
+              <Name>Heartbeats</Name>
+            </Expression>
+            <Expression xsi:type="SubscribeSubject">
+              <Name>ClockSynchronizerEvents</Name>
+            </Expression>
+            <Expression xsi:type="p1:Parse">
+              <harp:Register xsi:type="p1:Timer" />
+            </Expression>
+            <Expression xsi:type="rx:BehaviorSubject">
+              <Name>Timestamp</Name>
+            </Expression>
+            <Expression xsi:type="Combinator">
+              <Combinator xsi:type="rx:Take">
+                <rx:Count>1</rx:Count>
+              </Combinator>
+            </Expression>
+            <Expression xsi:type="Combinator">
+              <Combinator xsi:type="rx:WithLatestFrom" />
+            </Expression>
+            <Expression xsi:type="Subtract" />
+            <Expression xsi:type="rx:BehaviorSubject">
+              <Name>Timebase</Name>
+            </Expression>
+            <Expression xsi:type="WorkflowOutput" />
+          </Nodes>
+          <Edges>
+            <Edge From="0" To="1" Label="Source1" />
+            <Edge From="0" To="5" Label="Source1" />
+            <Edge From="1" To="2" Label="Source1" />
+            <Edge From="2" To="3" Label="Source1" />
+            <Edge From="3" To="4" Label="Source1" />
+            <Edge From="5" To="6" Label="Source1" />
+            <Edge From="6" To="7" Label="Source1" />
+            <Edge From="7" To="8" Label="Source1" />
+            <Edge From="7" To="9" Label="Source1" />
+            <Edge From="8" To="9" Label="Source2" />
+            <Edge From="9" To="10" Label="Source1" />
+            <Edge From="10" To="11" Label="Source1" />
+            <Edge From="11" To="12" Label="Source1" />
+          </Edges>
+        </Workflow>
+      </Expression>
+    </Nodes>
+    <Edges>
+      <Edge From="0" To="1" Label="Source1" />
+      <Edge From="1" To="2" Label="Source1" />
+      <Edge From="2" To="6" Label="Source1" />
+      <Edge From="3" To="4" Label="Source1" />
+      <Edge From="4" To="5" Label="Source1" />
+      <Edge From="5" To="6" Label="Source2" />
+      <Edge From="6" To="8" Label="Source1" />
+      <Edge From="7" To="8" Label="Source2" />
+      <Edge From="8" To="10" Label="Source1" />
+      <Edge From="9" To="10" Label="Source2" />
+      <Edge From="9" To="12" Label="Source1" />
+      <Edge From="10" To="11" Label="Source1" />
+    </Edges>
+  </Workflow>
+</WorkflowBuilder>

--- a/docs/assets/workflows/TimestampGeneratorGen3_Timestamps.bonsai
+++ b/docs/assets/workflows/TimestampGeneratorGen3_Timestamps.bonsai
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?>
+<WorkflowBuilder Version="2.9.0"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xmlns:harp="clr-namespace:Bonsai.Harp;assembly=Bonsai.Harp"
+                 xmlns:rx="clr-namespace:Bonsai.Reactive;assembly=Bonsai.Core"
+                 xmlns:p1="clr-namespace:Harp.TimestampGeneratorGen3;assembly=Harp.TimestampGeneratorGen3"
+                 xmlns="https://bonsai-rx.org/2018/workflow">
+  <Workflow>
+    <Nodes>
+      <Expression xsi:type="ExternalizedMapping">
+        <Property Name="Name" />
+      </Expression>
+      <Expression xsi:type="SubscribeSubject">
+        <Name>ClockSynchronizerEvents</Name>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="harp:FilterMessageType">
+          <harp:FilterType>Include</harp:FilterType>
+          <harp:MessageType>Event</harp:MessageType>
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="harp:FilterRegister">
+        <harp:FilterType>Include</harp:FilterType>
+        <harp:Register xsi:type="harp:TimestampSeconds" />
+      </Expression>
+      <Expression xsi:type="rx:PublishSubject">
+        <Name>Heartbeats</Name>
+      </Expression>
+      <Expression xsi:type="SubscribeSubject">
+        <Name>ClockSynchronizerEvents</Name>
+      </Expression>
+      <Expression xsi:type="p1:Parse">
+        <harp:Register xsi:type="p1:Timer" />
+      </Expression>
+      <Expression xsi:type="rx:BehaviorSubject">
+        <Name>Timestamp</Name>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="rx:Take">
+          <rx:Count>1</rx:Count>
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="rx:WithLatestFrom" />
+      </Expression>
+      <Expression xsi:type="Subtract" />
+      <Expression xsi:type="rx:BehaviorSubject">
+        <Name>Timebase</Name>
+      </Expression>
+      <Expression xsi:type="WorkflowOutput" />
+    </Nodes>
+    <Edges>
+      <Edge From="0" To="1" Label="Source1" />
+      <Edge From="0" To="5" Label="Source1" />
+      <Edge From="1" To="2" Label="Source1" />
+      <Edge From="2" To="3" Label="Source1" />
+      <Edge From="3" To="4" Label="Source1" />
+      <Edge From="5" To="6" Label="Source1" />
+      <Edge From="6" To="7" Label="Source1" />
+      <Edge From="7" To="8" Label="Source1" />
+      <Edge From="7" To="9" Label="Source1" />
+      <Edge From="8" To="9" Label="Source2" />
+      <Edge From="9" To="10" Label="Source1" />
+      <Edge From="10" To="11" Label="Source1" />
+      <Edge From="11" To="12" Label="Source1" />
+    </Edges>
+  </Workflow>
+</WorkflowBuilder>

--- a/src/UclOpen.Core/UclOpen.Core.csproj
+++ b/src/UclOpen.Core/UclOpen.Core.csproj
@@ -16,7 +16,6 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="YamlDotNet" Version="16.0.0" />
     <PackageReference Include="LibGit2Sharp" Version="0.31.0" />
-    <PackageReference Include="Harp.Behavior" Version="0.2.0" />
   </ItemGroup>
 
 </Project>

--- a/src/UclOpen.Devices/TimestampGeneratorGen3.bonsai
+++ b/src/UclOpen.Devices/TimestampGeneratorGen3.bonsai
@@ -1,0 +1,138 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<WorkflowBuilder Version="2.9.0"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xmlns:harp="clr-namespace:Bonsai.Harp;assembly=Bonsai.Harp"
+                 xmlns:rx="clr-namespace:Bonsai.Reactive;assembly=Bonsai.Core"
+                 xmlns:p1="clr-namespace:Harp.TimestampGeneratorGen3;assembly=Harp.TimestampGeneratorGen3"
+                 xmlns="https://bonsai-rx.org/2018/workflow">
+  <Workflow>
+    <Nodes>
+      <Expression xsi:type="Unit" />
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="harp:SynchronizeTimestamp" />
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="rx:Take">
+          <rx:Count>1</rx:Count>
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="ExternalizedMapping">
+        <Property Name="TimerFrequency" Description="The frequency at which to send timestamp events to Bonsai" />
+      </Expression>
+      <Expression xsi:type="p1:CreateMessage">
+        <harp:MessageType>Write</harp:MessageType>
+        <harp:Payload xsi:type="p1:CreateTimerFrequencyPayload">
+          <p1:TimerFrequency>Timer1000Hz</p1:TimerFrequency>
+        </harp:Payload>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="rx:Delay">
+          <rx:DueTime>PT0.1S</rx:DueTime>
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="rx:Concat" />
+      </Expression>
+      <Expression xsi:type="ExternalizedMapping">
+        <Property Name="PortName" />
+        <Property Name="DumpRegisters" />
+        <Property Name="Heartbeat" />
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="p1:Device">
+          <harp:OperationMode>Active</harp:OperationMode>
+          <harp:OperationLed>On</harp:OperationLed>
+          <harp:DumpRegisters>true</harp:DumpRegisters>
+          <harp:VisualIndicators>On</harp:VisualIndicators>
+          <harp:Heartbeat>Enabled</harp:Heartbeat>
+          <harp:IgnoreErrors>false</harp:IgnoreErrors>
+          <harp:PortName>COMx</harp:PortName>
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="ExternalizedMapping">
+        <Property Name="Name" DisplayName="EventsSubjectName" Description="The name of the output &quot;Events&quot; Subject" />
+      </Expression>
+      <Expression xsi:type="rx:PublishSubject">
+        <Name>ClockSynchronizerEvents</Name>
+      </Expression>
+      <Expression xsi:type="WorkflowOutput" />
+      <Expression xsi:type="GroupWorkflow">
+        <Name>Timestamps</Name>
+        <Workflow>
+          <Nodes>
+            <Expression xsi:type="ExternalizedMapping">
+              <Property Name="Name" />
+            </Expression>
+            <Expression xsi:type="SubscribeSubject">
+              <Name>ClockSynchronizerEvents</Name>
+            </Expression>
+            <Expression xsi:type="Combinator">
+              <Combinator xsi:type="harp:FilterMessageType">
+                <harp:FilterType>Include</harp:FilterType>
+                <harp:MessageType>Event</harp:MessageType>
+              </Combinator>
+            </Expression>
+            <Expression xsi:type="harp:FilterRegister">
+              <harp:FilterType>Include</harp:FilterType>
+              <harp:Register xsi:type="harp:TimestampSeconds" />
+            </Expression>
+            <Expression xsi:type="rx:PublishSubject">
+              <Name>Heartbeats</Name>
+            </Expression>
+            <Expression xsi:type="SubscribeSubject">
+              <Name>ClockSynchronizerEvents</Name>
+            </Expression>
+            <Expression xsi:type="p1:Parse">
+              <harp:Register xsi:type="p1:Timer" />
+            </Expression>
+            <Expression xsi:type="rx:BehaviorSubject">
+              <Name>Timestamp</Name>
+            </Expression>
+            <Expression xsi:type="Combinator">
+              <Combinator xsi:type="rx:Take">
+                <rx:Count>1</rx:Count>
+              </Combinator>
+            </Expression>
+            <Expression xsi:type="Combinator">
+              <Combinator xsi:type="rx:WithLatestFrom" />
+            </Expression>
+            <Expression xsi:type="Subtract" />
+            <Expression xsi:type="rx:BehaviorSubject">
+              <Name>Timebase</Name>
+            </Expression>
+            <Expression xsi:type="WorkflowOutput" />
+          </Nodes>
+          <Edges>
+            <Edge From="0" To="1" Label="Source1" />
+            <Edge From="0" To="5" Label="Source1" />
+            <Edge From="1" To="2" Label="Source1" />
+            <Edge From="2" To="3" Label="Source1" />
+            <Edge From="3" To="4" Label="Source1" />
+            <Edge From="5" To="6" Label="Source1" />
+            <Edge From="6" To="7" Label="Source1" />
+            <Edge From="7" To="8" Label="Source1" />
+            <Edge From="7" To="9" Label="Source1" />
+            <Edge From="8" To="9" Label="Source2" />
+            <Edge From="9" To="10" Label="Source1" />
+            <Edge From="10" To="11" Label="Source1" />
+            <Edge From="11" To="12" Label="Source1" />
+          </Edges>
+        </Workflow>
+      </Expression>
+    </Nodes>
+    <Edges>
+      <Edge From="0" To="1" Label="Source1" />
+      <Edge From="1" To="2" Label="Source1" />
+      <Edge From="2" To="6" Label="Source1" />
+      <Edge From="3" To="4" Label="Source1" />
+      <Edge From="4" To="5" Label="Source1" />
+      <Edge From="5" To="6" Label="Source2" />
+      <Edge From="6" To="8" Label="Source1" />
+      <Edge From="7" To="8" Label="Source2" />
+      <Edge From="8" To="10" Label="Source1" />
+      <Edge From="9" To="10" Label="Source2" />
+      <Edge From="9" To="12" Label="Source1" />
+      <Edge From="10" To="11" Label="Source1" />
+    </Edges>
+  </Workflow>
+</WorkflowBuilder>

--- a/src/UclOpen.Devices/UclOpen.Devices.csproj
+++ b/src/UclOpen.Devices/UclOpen.Devices.csproj
@@ -12,6 +12,9 @@
 
   <ItemGroup>
     <PackageReference Include="Bonsai.Core" Version="2.9.0" />
+    <PackageReference Include="Harp.Behavior" Version="0.2.0" />
+    <PackageReference Include="Harp.TimestampGeneratorGen3" Version="0.1.1" />
+    <PackageReference Include="AllenNeuralDynamics.LicketySplit" Version="0.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ucl_open/devices/harp.py
+++ b/src/ucl_open/devices/harp.py
@@ -13,7 +13,13 @@ class HarpClockSynchronizer(HarpDevice):
 
 
 class HarpTimestampGeneratorGen3(HarpDevice):
+    """Harp Timestamp Generator Gen3 (who_am_i=1158). Provides hardware clock synchronisation."""
+
     who_am_i: ClassVar[int] = 1158
+    timer_frequency: Literal["Disabled", "Timer50Hz", "Timer100Hz", "Timer200Hz", "Timer500Hz", "Timer1000Hz"] = Field(
+        default="Timer1000Hz",
+        description="Frequency of the timer output signal.",
+    )
 
 
 class HarpCameraControllerGen2(HarpDevice):

--- a/src/ucl_open/devices/harp.py
+++ b/src/ucl_open/devices/harp.py
@@ -1,6 +1,16 @@
+from enum import StrEnum
 from typing import ClassVar
 from pydantic import Field
 from swc.aeon.schema import BaseSchema
+
+
+class TimerFrequency(StrEnum):
+    Disabled = "Disabled"
+    Timer50Hz = "Timer50Hz"
+    Timer100Hz = "Timer100Hz"
+    Timer200Hz = "Timer200Hz"
+    Timer500Hz = "Timer500Hz"
+    Timer1000Hz = "Timer1000Hz"
 
 
 class HarpDevice(BaseSchema):
@@ -16,8 +26,8 @@ class HarpTimestampGeneratorGen3(HarpDevice):
     """Harp Timestamp Generator Gen3 (who_am_i=1158). Provides hardware clock synchronisation."""
 
     who_am_i: ClassVar[int] = 1158
-    timer_frequency: Literal["Disabled", "Timer50Hz", "Timer100Hz", "Timer200Hz", "Timer500Hz", "Timer1000Hz"] = Field(
-        default="Timer1000Hz",
+    timer_frequency: TimerFrequency = Field(
+        default=TimerFrequency.Timer1000Hz,
         description="Frequency of the timer output signal.",
     )
 

--- a/template/template/.bonsai/Bonsai.config.jinja
+++ b/template/template/.bonsai/Bonsai.config.jinja
@@ -1,7 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageConfiguration xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Packages>
-    <Package id="Aeon.Acquisition" version="0.6.0" />
     <Package id="AllenNeuralDynamics.LicketySplit" version="0.2.0" />
     <Package id="AsyncIO" version="0.1.69" />
     <Package id="Bonsai" version="2.9.0" />
@@ -62,7 +61,6 @@
     <Package id="YamlDotNet" version="16.3.0" />
   </Packages>
   <AssemblyReferences>
-    <AssemblyReference assemblyName="Aeon.Acquisition" />
     <AssemblyReference assemblyName="AllenNeuralDynamics.LicketySplit" />
     <AssemblyReference assemblyName="Bonsai" />
     <AssemblyReference assemblyName="Bonsai.Arduino" />
@@ -93,7 +91,6 @@
     <AssemblyReference assemblyName="UclOpen.Video" />
   </AssemblyReferences>
   <AssemblyLocations>
-    <AssemblyLocation assemblyName="Aeon.Acquisition" processorArchitecture="MSIL" location="Packages/Aeon.Acquisition.0.6.0/lib/net472/Aeon.Acquisition.dll" />
     <AssemblyLocation assemblyName="AllenNeuralDynamics.LicketySplit" processorArchitecture="MSIL" location="Packages/AllenNeuralDynamics.LicketySplit.0.2.0/lib/net462/AllenNeuralDynamics.LicketySplit.dll" />
     <AssemblyLocation assemblyName="AsyncIO" processorArchitecture="MSIL" location="Packages/AsyncIO.0.1.69/lib/net40/AsyncIO.dll" />
     <AssemblyLocation assemblyName="Basler.Pylon" processorArchitecture="X86" location="Packages/Bonsai.Pylon.0.3.0/build/net462/bin/x86/Basler.Pylon.dll" />

--- a/template/template/pyproject.toml.jinja
+++ b/template/template/pyproject.toml.jinja
@@ -28,6 +28,7 @@ dependencies = [
 # Changelog = "https://github.com/UclOpen/{{ dotnet_full_name }}/releases"
 [project.scripts]
 {{ project_name }} = "{{ python_folder_name }}.cli:main"
+regenerate-schemas = "{{ python_folder_name }}.regenerate:main"
 
 [tool.ruff]
 line-length = 120

--- a/template/template/scripts/deploy.ps1
+++ b/template/template/scripts/deploy.ps1
@@ -5,38 +5,42 @@ Set-Location (Split-Path -Parent $scriptDirectory)
 Write-Output "Initializing and updating submodules..."
 &git submodule update --init --recursive
 
-Write-Output "Creating a Python  environment..."
-
 if (-not (Get-Command uv -ErrorAction SilentlyContinue)) {
     throw "The 'uv' command was not found. See https://docs.astral.sh/uv/getting-started/installation/ for instructions."
 }
 
+Write-Output "Creating a Python environment..."
 if (Test-Path -Path ./.venv) {
     Remove-Item ./.venv -Recurse -Force
 }
 &uv venv
 .\.venv\Scripts\Activate.ps1
 Write-Output "Synchronizing environment..."
-&uv sync 
+&uv sync
 
-Write-Output "Creating a Bonsai environment and installing packages..."
-if (Test-Path -Path "bonsai") {
-    Set-Location "bonsai"
-    .\setup.ps1
-} elseif (Test-Path -Path ".bonsai") {
-    Set-Location ".bonsai"
-    .\setup.ps1
-} else {
-    throw "Neither 'bonsai' nor '.bonsai' directory found."
-}
-Set-Location ..
+Write-Output "Regenerating JSON schema from pydantic models..."
+&uv run regenerate-schemas
 
-if (-not (Test-Path -Path src\Extensions)) {
-    Write-Output "Creating bonsai extensions folder..."
-    New-Item -ItemType Directory -Path src\Extensions | Out-Null
+if (-not (Get-Command dotnet -ErrorAction SilentlyContinue)) {
+    throw "The 'dotnet' command was not found. Install the .NET SDK: https://dotnet.microsoft.com/download"
 }
+
+Write-Output "Restoring dotnet tools..."
+&dotnet tool restore
+
+# Derive C# namespace from schema filename (snake_case -> PascalCase).
+$schemaFile = Get-ChildItem ".\src\DataSchemas\*.json" | Select-Object -First 1
+if (-not $schemaFile) { throw "No JSON schema found in .\src\DataSchemas\. Run 'uv run regenerate-schemas' first." }
+$namespace = ($schemaFile.BaseName -split "_" | ForEach-Object { $_.Substring(0,1).ToUpper() + $_.Substring(1) }) -join ""
+
+Write-Output "Generating C# classes (namespace: $namespace, serializers: json yaml)..."
+Push-Location .\src\Extensions
+&dotnet bonsai.sgen $schemaFile.FullName --namespace $namespace --serializer json --serializer yaml
+Pop-Location
 
 if (-not (Test-Path -Path src\DataSchemas)) {
-    Write-Output "Creating sgen output folder..."
     New-Item -ItemType Directory -Path src\DataSchemas | Out-Null
+}
+if (-not (Test-Path -Path src\Extensions)) {
+    New-Item -ItemType Directory -Path src\Extensions | Out-Null
 }

--- a/template/template/src/{{ python_folder_name }}/regenerate.py.jinja
+++ b/template/template/src/{{ python_folder_name }}/regenerate.py.jinja
@@ -1,16 +1,13 @@
 from pathlib import Path
 from typing import Union
-
+import json
 import pydantic
-from ucl_open.rigs.experiment import Experiment
-from aind_behavior_services.utils import BonsaiSgenSerializers, convert_pydantic_to_bonsai
 
 import {{ python_folder_name }}.rig
 import {{ python_folder_name }}.task
 
 SCHEMA_ROOT = Path("./src/DataSchemas/")
-EXTENSIONS_ROOT = Path("./src/Extensions/")
-NAMESPACE_PREFIX = "{{ python_class_prefix }}DataSchema"
+SCHEMA_FILE = SCHEMA_ROOT / "{{ python_folder_name }}.json"
 
 
 def main():
@@ -19,16 +16,10 @@ def main():
         {{ python_folder_name }}.rig.{{ python_class_prefix }}Rig,
     ]
     model = pydantic.RootModel[Union[tuple(models)]]
-
-    convert_pydantic_to_bonsai(
-        model, # type: ignore
-        model_name="{{ python_folder_name }}",
-        root_element="Root",
-        cs_namespace=NAMESPACE_PREFIX,
-        json_schema_output_dir=SCHEMA_ROOT,
-        cs_output_dir=EXTENSIONS_ROOT,
-        cs_serializer=[BonsaiSgenSerializers.JSON],
-    )
+    schema = model.model_json_schema(by_alias=True, mode="serialization", union_format="primitive_type_array")
+    SCHEMA_ROOT.mkdir(parents=True, exist_ok=True)
+    SCHEMA_FILE.write_text(json.dumps(schema, indent=2))
+    print(f"Schema written to {SCHEMA_FILE}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds full platform support for the Harp Timestamp Generator Gen3

Schema (harp.py) - expands HarpTimestampGeneratorGen3 with a timer_frequency field; introduces TimerFrequency as a field
Bonsai workflow (TimestampGeneratorGen3.bonsai) - new operator for use in experiment workflows.
Docs - new device page at docs/articles/devices/harp-timestamp-generator-gen3.md 