### PR TITLE
Update regenerate template to include session and sgen generation

### DIFF
--- a/template/template/src/{{ python_folder_name }}/regenerate.py.jinja
+++ b/template/template/src/{{ python_folder_name }}/regenerate.py.jinja
@@ -2,7 +2,9 @@ from pathlib import Path
 from typing import Union
 import json
 import pydantic
+import os
 
+from ucl_open.core import ExperimentSession
 import {{ python_folder_name }}.rig
 import {{ python_folder_name }}.task
 
@@ -14,12 +16,14 @@ def main():
     models = [
         {{ python_folder_name }}.task.{{ python_class_prefix }}TaskLogic,
         {{ python_folder_name }}.rig.{{ python_class_prefix }}Rig,
+        ExperimentSession
     ]
     model = pydantic.RootModel[Union[tuple(models)]]
     schema = model.model_json_schema(by_alias=True, mode="serialization", union_format="primitive_type_array")
     SCHEMA_ROOT.mkdir(parents=True, exist_ok=True)
     SCHEMA_FILE.write_text(json.dumps(schema, indent=2))
     print(f"Schema written to {SCHEMA_FILE}")
+    os.system("dotnet bonsai.sgen src/DataSchemas/{{ python_folder_name }}.json --output src/Extensions --serializer json --serializer yaml")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The PR updates the template regenerate script to include all models (including `ExperimentSession`) and a call to bonsai sgen such that the full process of json compiling and generated C# classes is done from one script.