### PR TITLE
Fix missing comma in template pyproject.toml.jinja dependencies

### DIFF
--- a/template/template/pyproject.toml.jinja
+++ b/template/template/pyproject.toml.jinja
@@ -18,7 +18,7 @@ readme = {file = "README.md", content-type = "text/markdown"}
 dependencies = [
   "swc-aeon>=0.2.0",
   "ucl-open",
-  "pydantic-settings"
+  "pydantic-settings",
   "aind_behavior_services>=0.13"
 ]
 


### PR DESCRIPTION
Adds missing comma between `"pydantic-settings"` and `"aind_behavior_services>=0.13"` in the `dependencies` list of `template/template/pyproject.toml.jinja`.

Closes #39.
