### PR TITLE
Streaming package

### DIFF
--- a/UclOpen.sln
+++ b/UclOpen.sln
@@ -1,4 +1,4 @@
-Microsoft Visual Studio Solution File, Format Version 12.00
+﻿Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.3.32825.248
 MinimumVisualStudioVersion = 10.0.40219.1
@@ -21,6 +21,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{DEE5DD87
 		build\Package.props = build\Package.props
 		build\Project.csproj.props = build\Project.csproj.props
 	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{7154D3D2-411E-41E4-A36C-58A4FFCC6A56}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UclOpen.Streaming", "src\UclOpen.Streaming\UclOpen.Streaming.csproj", "{AEA91477-0205-4F07-92D8-27A628BA63F5}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -48,11 +52,18 @@ Global
 		{ABC3E39D-3D71-4F2D-BBE9-2C76A93EE487}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{ABC3E39D-3D71-4F2D-BBE9-2C76A93EE487}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{ABC3E39D-3D71-4F2D-BBE9-2C76A93EE487}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AEA91477-0205-4F07-92D8-27A628BA63F5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AEA91477-0205-4F07-92D8-27A628BA63F5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AEA91477-0205-4F07-92D8-27A628BA63F5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AEA91477-0205-4F07-92D8-27A628BA63F5}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {6BCBC17F-9E00-4ABC-9CEE-ABB0337E929D}
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{AEA91477-0205-4F07-92D8-27A628BA63F5} = {7154D3D2-411E-41E4-A36C-58A4FFCC6A56}
 	EndGlobalSection
 EndGlobal

--- a/docs/bonsai-operators/UclOpen.Streaming/pack-data-message.md
+++ b/docs/bonsai-operators/UclOpen.Streaming/pack-data-message.md
@@ -1,0 +1,50 @@
+# Pack Data Message
+
+`PackDataMessage` serializes a value to JSON, wraps it in a topic and header, and publishes it on
+the data socket held by [Stream Controller](stream-controller.md). It accepts any type, so a stream
+can carry a number, a string, a tuple or a schema type without an operator per case. One instance is
+needed per logical stream.
+
+---
+
+## Bonsai workflow
+
+:::workflow
+![PackDataMessage](~/assets/workflows/streaming/PackDataMessage.svg){data-bonsai="~/src/UclOpen.Streaming/PackDataMessage.bonsai"}
+:::
+
+Each value passes through three steps:
+
+- **SerializeStream** - serializes the value to JSON and records the name of its runtime type.
+- **BuildMessage** - attaches the topic and header, with `Encoding` fixed to `json` and
+  `PayloadType` taken from the serialized type name.
+- **MulticastSubject** - publishes on `DataMessage`, the subject the controller's socket subscribes
+  to.
+
+### Externalized properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| `StreamName` | `data` | The chosen stream name, used in both the topic and the header |
+
+### Stream names
+
+`StreamName` becomes the second segment of the topic, so a value packed as `trial` from rig `MyRig`
+publishes on `MyRig/trial/`. Names may be hierarchical: publishing `data/first` and `data/second`
+lets a subscriber take both by asking for `data`, or either one by asking for the full name. Give the
+`StreamName` without a trailing slash — `ReceiveStream` appends one when it builds the topic, so
+`data/` would produce `MyRig/data//` and match nothing.
+
+---
+
+## Usage
+
+Connect any value to `PackDataMessage` and give it a stream name. Here two packers publish an `int` and a `double` on separate streams through the same socket owned by [Stream Controller](stream-controller.md):
+
+:::workflow
+![StreamingSend](~/workflows/StreamingSend.bonsai)
+:::
+
+One instance per stream. Two packers sharing a `StreamName` will interleave into one stream and corrupt its message index, so give each its own name.
+
+Serialization happens on every message, so avoid pointing a packer at a high-rate source that a subscriber does not need at full rate — decimate with `Sample` or `Throttle` upstream, as [Pack Video Message](pack-video-message.md) does for frames.

--- a/docs/bonsai-operators/UclOpen.Streaming/pack-video-message.md
+++ b/docs/bonsai-operators/UclOpen.Streaming/pack-video-message.md
@@ -1,0 +1,44 @@
+# Pack Video Message
+
+`PackVideoMessage` turns a camera stream into a stream of JPEG frames small enough to watch over a network. It samples the incoming frames down to a viewing rate, resizes them, encodes each as JPEG, and publishes on the video socket held by [Stream Controller](stream-controller.md). One instance is needed per camera.
+
+---
+
+## Bonsai workflow
+
+:::workflow
+![PackVideoMessage](~/assets/workflows/streaming/PackVideoMessage.svg){data-bonsai="~/src/UclOpen.Streaming/PackVideoMessage.bonsai"}
+:::
+
+Frames pass through four steps before packing:
+
+- **SampleInterval** - downsampling in time, taking the most recent frame at each tick.
+- **Resize** - downsampling in space, to `FrameSize`.
+- **EncodeImage** - JPEG encoding.
+- **BuildMessage** - attaches the topic and header, with `Encoding` set to `jpeg` and `PayloadType`
+  to `Image`.
+
+`SampleInterval` samples rather than counting: it emits the *most recent* frame at each tick, so the stream rate is independent of the acquisition rate. 
+
+### Externalized properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| `SampleInterval` | `PT0.2S` | How often to take a frame. Downsampling in time, applied before any other work |
+| `FrameSize` | `320 x 240` | Size of the streamed frames. Downsampling in space |
+| `Interpolation` | `Linear` | Interpolation used when resizing |
+| `StreamName` | `video` | The chosen stream name, used in both the topic and the header |
+
+---
+
+## Usage
+
+Connect a camera stream to `PackVideoMessage`:
+
+```
+CameraCapture -> PackVideoMessage   (StreamName = video)
+```
+
+One instance per camera, each with its own `StreamName`. Hierarchical names group them: cameras published as `video/face` and `video/body` can both be picked up by a subscription to `video`.
+
+The defaults are chosen for monitoring, not for analysis or logging. The stream is deliberately lossy and re-encoded. Logging should be done directly at the publishing, acquisition machine.

--- a/docs/bonsai-operators/UclOpen.Streaming/receive-stream.md
+++ b/docs/bonsai-operators/UclOpen.Streaming/receive-stream.md
@@ -1,0 +1,44 @@
+# Receive Stream
+
+`ReceiveStream` subscribes to a single stream on a remote machine and unpacks each arriving message into its topic, header and payload. It has the reverse behaviour to [Pack Data Message](pack-data-message.md), and is normally followed by `SelectStreamPayload`, which turns the raw payload back into the type that was sent.
+
+---
+
+## Bonsai workflow
+
+:::workflow
+![ReceiveStream](~/assets/workflows/streaming/ReceiveStream.svg){data-bonsai="~/src/UclOpen.Streaming/ReceiveStream.bonsai"}
+:::
+
+- **Subscriber** - connects to the publisher and receives only messages whose topic matches the prefix.
+- **ParseStreamMessage** - splits the three frames into a `StreamMessage` carrying `Topic`, `Header`, `Payload` and `Valid`.
+
+A message whose header cannot be parsed is marked `Valid = false` and passed through rather than terminating the sequence, so one malformed message cannot take down a long-running display. See [UclOpen.Streaming.ParseStreamMessage](xref:UclOpen.Streaming.ParseStreamMessage).
+
+### Externalized properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| `RigId` | `MyRig` | Identifier of the rig to subscribe to. Must match the publisher's `RigId` |
+| `StreamName` | `data` | Stream to subscribe to. Must match the publisher's `StreamName` |
+| `ConnectionString` | `>tcp://127.0.0.1:5556` | Publisher endpoint to connect to |
+
+---
+
+## Selecting the payload type
+
+`ReceiveStream` alone gives raw bytes. Follow it with `SelectStreamPayload` and set `Type` to what the publisher sent, and the output reduces to three useful fields — `SessionKey`, `Index` and `Value` — with `Value` already the right type.
+
+:::workflow
+![StreamingReceive](~/workflows/StreamingReceive.bonsai)
+:::
+
+The type must match what was published; the `type` header field records what that was. The selectable types are declared as attributes on the operator and the list is maintained by hand, so a type that is not yet listed cannot be chosen until it is added. See [UclOpen.Streaming.SelectStreamPayload](xref:UclOpen.Streaming.SelectStreamPayload).
+
+`Index` increments per stream, so you can detect dropped messages from non-monotonic increments. Note that gaps are not neccessarily a fault. The publisher drops messages instead of blocking when a subscriber cannot keep up. So dropped frames at the remote monitor does not mean dropped frames at the rig.
+
+---
+
+## Usage
+
+`StreamName` matches by prefix, so subscribing to `data` picks up both `data/first` and `data/second`. That is useful for a display that wants everything a rig emits, but note the streams then interleave in one sequence. Filter on `Topic` to separate them, or subscribe to the full names separately.

--- a/docs/bonsai-operators/UclOpen.Streaming/receive-video.md
+++ b/docs/bonsai-operators/UclOpen.Streaming/receive-video.md
@@ -1,0 +1,43 @@
+# Receive Video
+
+`ReceiveVideo` subscribes to a video stream on a remote machine and decodes each arriving frame back into an image. It has the reverse behaviour to [Pack Video Message](pack-video-message.md) and differs from [Receive Stream](receive-stream.md) only in what it does with the payload: JPEG frames are decoded rather than deserialized from JSON.
+
+---
+
+## Bonsai workflow
+
+:::workflow
+![ReceiveVideo](~/assets/workflows/streaming/ReceiveVideo.svg){data-bonsai="~/src/UclOpen.Streaming/ReceiveVideo.bonsai"}
+:::
+
+- **DecodeImage** - decodes the JPEG payload into an image.
+- **SelectStreamValue** - zips the decoded image back with the message it came from and attaches
+  `SessionKey` and `Index`.
+
+### Externalized properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| `RigId` | `MyRig` | Identifier of the rig to subscribe to. Must match the publisher's `RigId` |
+| `StreamName` | `video` | Video stream to subscribe to. Must match the publisher's `StreamName` |
+| `ConnectionString` | `>tcp://127.0.0.1:5558` | Publisher endpoint to connect to, for example `>tcp://rig-machine:5558` |
+| `Mode` | `Unchanged` | Optional conversion applied to the decoded image, for example grayscale |
+
+Note the default port is `5558`, not the `5556` used for data — [Stream Controller](stream-controller.md)
+binds video on its own socket, since video is typically far more dense than many streams of data.
+
+---
+
+## Usage
+
+Connect the output to a visualizer to watch a remote camera:
+
+```
+ReceiveVideo -> Value
+  RigId = MyRig
+  StreamName = video
+  ConnectionString = >tcp://rig-machine:5558
+```
+
+Frames arrive at the publisher's `SampleInterval` rate, resized and JPEG-compressed. The stream is
+for monitoring. Video frames and a subscriber have been through a lossy round trip and should not be analysed.

--- a/docs/bonsai-operators/UclOpen.Streaming/stream-controller.md
+++ b/docs/bonsai-operators/UclOpen.Streaming/stream-controller.md
@@ -1,0 +1,38 @@
+# Stream Controller
+
+The `StreamController` operator owns the ZeroMQ publisher sockets and the identity carried by every streamed message. It assembles a `StreamIdentity` subject from the rig ID, subject ID and session ID, which all packing operators consume to build their topic and header. There should be a `StreamController` at the top of any workflow that streams. It must exist so that the `StreamIdentity` subject is available, and so that something binds the sockets. without it the packing operators have nowhere to publish.
+
+---
+
+## Bonsai workflow
+
+:::workflow
+![StreamController](~/assets/workflows/streaming/StreamController.svg){data-bonsai="~/src/UclOpen.Streaming/StreamController.bonsai"}
+:::
+
+The operator publishes the rig identity once, then opens two publisher sockets:
+
+- **DataMessage** - bound to `@tcp://0.0.0.0:5556`, carrying everything from [Pack Data Message](pack-data-message.md).
+- **VideoMessage** - bound to `@tcp://0.0.0.0:5558`, carrying everything from [Pack Video Message](pack-video-message.md).
+
+Within each socket any number of streams share the connection, separated by topic. This can be extended to further sockets in future.
+
+Packing operators reach the sockets through a `MulticastSubject` rather than a direct conenction, so a `StreamController` anywhere in the workflow serves every packer.
+
+### Externalized properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| `RigId` | `MyRig` | The rig identifier included in every published topic |
+| `SubjectId` | `Algernon` | The subject identifier, matching the logging session directory |
+| `SessionId` | `001` | The session identifier, matching the logging session directory |
+
+`SubjectId` and `SessionId` combine into the `sessionKey` header field. Setting them to match the values given to `LogController` is what lets a streamed record be traced back to the data on disk.
+
+---
+
+## Usage
+
+One `StreamController` per workflow. `RigId` must match the `RigId` set on any [Receive Stream](receive-stream.md) or [Receive Video](receive-video.md).
+
+The default `0.0.0.0` binds on all interfaces, which is what cross-machine streaming needs. See the [overview](streaming.md#cross-machine-setup).

--- a/docs/bonsai-operators/UclOpen.Streaming/streaming.md
+++ b/docs/bonsai-operators/UclOpen.Streaming/streaming.md
@@ -1,0 +1,104 @@
+# Overview
+
+`UclOpen.Streaming` contains Bonsai operators to stream live experiment telemetry over ZeroMQ, and receive it on a remote machine. A rig publishes values, images and events as they happen; a machine elsewhere on the same network subscribes to the named stream and returns them in their original types.
+This can be useful for remote monitoring and control of an ongoing experiment, allowing the delegation of sometimes heavy GUIs to a different machine than acquisition. For this reason, a publisher drops messages rather than blocking when a subscriber cannot keep up, so a slow remote viewer can never hold up acquisition. This makes it suitable for monitoring and remote displays, but unsuitable for collecting data to log. Logging should still be performed at the acqusition machine.
+
+---
+
+## Operators
+
+| Operator | Role |
+|----------|------|
+| `StreamController` | Opens the sockets, declares data and video `Subjects` and defines and publishes rig/session identity. |
+| `PackDataMessage` | Serializes a value and packs it into a message with Topic, JSON header and payload. |
+| `PackVideoMessage` | Decimates, resizes, encodes and packs video frames into ZeroMQ messages. |
+| `ReceiveStream` | Subscribes to a named stream and unpacks to a `StreamMessage`. |
+| `SelectStreamPayload` | Deserializes the payload into `SessionKey`, `Index` and `Value`. |
+| `ReceiveVideo` | As `ReceiveStream`, but decodes frames to an image. |
+
+Sending is `value` -> `PackDataMessage` -> `MulticastSubject`, with `StreamController` owning the
+socket. Receiving is `ReceiveStream` -> `SelectStreamPayload`, where the expected type is set on the
+second node.
+
+---
+
+## Quick start
+
+Put a `StreamController` at the top of a workflow and set its `RigId`, then send any value into a
+`PackDataMessage` with a `StreamName`. The controller's publisher socket picks the message up from
+there, so the two need no wire between them — which is why `StreamController` sits on its own below.
+Any number of streams share the one socket:
+
+:::workflow
+![StreamingSend](~/workflows/StreamingSend.bonsai)
+:::
+
+On the receiving machine, subscribe to the same rig and declare the type you expect. Subscribing to `data` picks up all streams under `data/`, and a `Condition` on `Topic` can split them
+again:
+
+:::workflow
+![StreamingReceive](~/workflows/StreamingReceive.bonsai)
+:::
+
+`SelectStreamPayload` parses each message to `SessionKey`, `Index` and `Value`, where `Value` has the type the publisher sent rather than a JSON string.
+
+---
+
+## Wire contract
+
+Three frames per message:
+
+| Frame | Contents |
+|-------|----------|
+| 0 | Topic — `{rigId}/{stream}/`, trailing slash included |
+| 1 | Header — JSON string |
+| 2 | Payload — encoded as named by `enc` |
+
+The header carries six fields:
+
+| Field | Description |
+|-------|-------------|
+| `rigId` | Identifier of the publishing rig |
+| `sessionKey` | Session the message belongs to, ideally matching the logging directory |
+| `stream` | Stream name |
+| `index` | Per-stream message counter |
+| `enc` | Payload encoding: typically `json` or `jpeg` |
+| `type` | The payload type, so a receiver knows what to deserialize into |
+
+`sessionKey` should match the directory created by the logging package, so a streamed record traces back to the data on disk. `index` increments per stream, allowing the receiver to detect dropped frames. `type` names the payload type.
+
+Message format is ZeroMQ and JSON, so a consumer need not be Bonsai. Any language with a ZeroMQ binding — Python, for example — can subscribe by topic prefix.
+
+### Topic filtering notes
+
+The trailing slash matters: without it a subscription to `MyRig/trial/` would also match `MyRig/trialSummary/`. It also means hierarchical names work — a camera published as `video/face` is picked up by a subscription to `video`, and a rig publishing `data/first` and `data/second` serves both to a subscriber asking for `data`.
+
+Taking a group of streams and separating them again is done using a `Condition` on `Topic`. 
+
+:::workflow
+![StreamingReceive](~/workflows/StreamingReceive.bonsai)
+:::
+
+### Internal includes
+
+Two workflows in the package are plumbing rather than operators that you would usually place by hand:
+
+- **CreateEnvelope** - builds the topic string and the JSON header from the stream identity plus the
+  `StreamName`, `Encoding` and `PayloadType` properties.
+- **BuildMessage** - takes an encoded payload and the envelope and assembles the three-frame
+  `NetMQMessage`.
+
+`PackDataMessage` and `PackVideoMessage` both include `BuildMessage`, which in turn includes
+`CreateEnvelope`. Use them directly only when adding a new packer for an encoding the package does
+not cover.
+
+---
+
+## Cross-machine setup
+
+Bind and connect are different: `@tcp://…` binds, `>tcp://…` connects. A publisher binds and a
+subscriber connects. A useful side effect of this behaviour is that it does not cost the network time or bandwidth to publish any stream if there is no subscriber. 
+
+Set `0.0.0.0` on the publishing machine. This binds the stream to the local machine Network Interface Card, using the IP address assigned to that machine. The subscribing machine can then connect to this using the IP address of the publishing machine, and the same port (5556 for data, 5558 for video). You can find the IP address from the publishing machine in the command prompt by typing ipconfig /all. Look for the IPv4 address.
+
+---

--- a/docs/bonsai-operators/toc.yml
+++ b/docs/bonsai-operators/toc.yml
@@ -35,6 +35,20 @@
     href: UclOpen.Logging/log-harp-device.md
   - name: Log Video
     href: UclOpen.Logging/log-video.md
+- name: UclOpen.Streaming
+  items:
+  - name: Overview
+    href: UclOpen.Streaming/streaming.md
+  - name: Stream Controller
+    href: UclOpen.Streaming/stream-controller.md
+  - name: Pack Data Message
+    href: UclOpen.Streaming/pack-data-message.md
+  - name: Pack Video Message
+    href: UclOpen.Streaming/pack-video-message.md
+  - name: Receive Stream
+    href: UclOpen.Streaming/receive-stream.md
+  - name: Receive Video
+    href: UclOpen.Streaming/receive-video.md
 - name: UclOpen.Vision
   items:
   - name: Sync Quad

--- a/docs/workflows/StreamingReceive.bonsai
+++ b/docs/workflows/StreamingReceive.bonsai
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="utf-8"?>
+<WorkflowBuilder Version="2.9.0"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xmlns:rx="clr-namespace:Bonsai.Reactive;assembly=Bonsai.Core"
+                 xmlns:p1="clr-namespace:UclOpen.Streaming;assembly=UclOpen.Streaming"
+                 xmlns:sys="clr-namespace:System;assembly=mscorlib"
+                 xmlns="https://bonsai-rx.org/2018/workflow">
+  <Workflow>
+    <Nodes>
+      <Expression xsi:type="IncludeWorkflow" Path="UclOpen.Streaming:ReceiveStream.bonsai">
+        <RigId>MyRig</RigId>
+        <StreamName>data</StreamName>
+        <ConnectionString>&gt;tcp://127.0.0.1:5556</ConnectionString>
+      </Expression>
+      <Expression xsi:type="rx:PublishSubject">
+        <Name>Message</Name>
+      </Expression>
+      <Expression xsi:type="SubscribeSubject">
+        <Name>Message</Name>
+      </Expression>
+      <Expression xsi:type="rx:Condition">
+        <Workflow>
+          <Nodes>
+            <Expression xsi:type="WorkflowInput">
+              <Name>Source1</Name>
+            </Expression>
+            <Expression xsi:type="MemberSelector">
+              <Selector>Topic</Selector>
+            </Expression>
+            <Expression xsi:type="Equal">
+              <Operand xsi:type="StringProperty">
+                <Value>MyRig/data/first/</Value>
+              </Operand>
+            </Expression>
+            <Expression xsi:type="WorkflowOutput" />
+          </Nodes>
+          <Edges>
+            <Edge From="0" To="1" Label="Source1" />
+            <Edge From="1" To="2" Label="Source1" />
+            <Edge From="2" To="3" Label="Source1" />
+          </Edges>
+        </Workflow>
+      </Expression>
+      <Expression xsi:type="p1:SelectStreamPayload">
+        <p1:Type xsi:type="TypeMapping" TypeArguments="sys:Int32" />
+      </Expression>
+      <Expression xsi:type="MemberSelector">
+        <Selector>Value</Selector>
+      </Expression>
+      <Expression xsi:type="SubscribeSubject">
+        <Name>Message</Name>
+      </Expression>
+      <Expression xsi:type="rx:Condition">
+        <Workflow>
+          <Nodes>
+            <Expression xsi:type="WorkflowInput">
+              <Name>Source1</Name>
+            </Expression>
+            <Expression xsi:type="MemberSelector">
+              <Selector>Topic</Selector>
+            </Expression>
+            <Expression xsi:type="Equal">
+              <Operand xsi:type="StringProperty">
+                <Value>MyRig/data/second/</Value>
+              </Operand>
+            </Expression>
+            <Expression xsi:type="WorkflowOutput" />
+          </Nodes>
+          <Edges>
+            <Edge From="0" To="1" Label="Source1" />
+            <Edge From="1" To="2" Label="Source1" />
+            <Edge From="2" To="3" Label="Source1" />
+          </Edges>
+        </Workflow>
+      </Expression>
+      <Expression xsi:type="p1:SelectStreamPayload">
+        <p1:Type xsi:type="TypeMapping" TypeArguments="sys:Double" />
+      </Expression>
+      <Expression xsi:type="MemberSelector">
+        <Selector>Value</Selector>
+      </Expression>
+    </Nodes>
+    <Edges>
+      <Edge From="0" To="1" Label="Source1" />
+      <Edge From="2" To="3" Label="Source1" />
+      <Edge From="3" To="4" Label="Source1" />
+      <Edge From="4" To="5" Label="Source1" />
+      <Edge From="6" To="7" Label="Source1" />
+      <Edge From="7" To="8" Label="Source1" />
+      <Edge From="8" To="9" Label="Source1" />
+    </Edges>
+  </Workflow>
+</WorkflowBuilder>

--- a/docs/workflows/StreamingSend.bonsai
+++ b/docs/workflows/StreamingSend.bonsai
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<WorkflowBuilder Version="2.9.0"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xmlns:rx="clr-namespace:Bonsai.Reactive;assembly=Bonsai.Core"
+                 xmlns="https://bonsai-rx.org/2018/workflow">
+  <Workflow>
+    <Nodes>
+      <Expression xsi:type="IncludeWorkflow" Path="UclOpen.Streaming:StreamController.bonsai">
+        <RigId>MyRig</RigId>
+        <SubjectId>Algernon</SubjectId>
+        <SessionId>001</SessionId>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="rx:Timer">
+          <rx:DueTime>PT0.5S</rx:DueTime>
+          <rx:Period>PT1S</rx:Period>
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="IntProperty">
+          <Value>42</Value>
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="IncludeWorkflow" Path="UclOpen.Streaming:PackDataMessage.bonsai">
+        <StreamName>data/first</StreamName>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="rx:Timer">
+          <rx:DueTime>PT0S</rx:DueTime>
+          <rx:Period>PT1S</rx:Period>
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="DoubleProperty">
+          <Value>142</Value>
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="IncludeWorkflow" Path="UclOpen.Streaming:PackDataMessage.bonsai">
+        <StreamName>data/second</StreamName>
+      </Expression>
+    </Nodes>
+    <Edges>
+      <Edge From="1" To="2" Label="Source1" />
+      <Edge From="2" To="3" Label="Source1" />
+      <Edge From="4" To="5" Label="Source1" />
+      <Edge From="5" To="6" Label="Source1" />
+    </Edges>
+  </Workflow>
+</WorkflowBuilder>

--- a/examples/streaming/StreamData.bonsai
+++ b/examples/streaming/StreamData.bonsai
@@ -1,0 +1,182 @@
+<?xml version="1.0" encoding="utf-8"?>
+<WorkflowBuilder Version="2.9.1"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xmlns:rx="clr-namespace:Bonsai.Reactive;assembly=Bonsai.Core"
+                 xmlns:p1="clr-namespace:UclOpen.Streaming;assembly=UclOpen.Streaming"
+                 xmlns:sys="clr-namespace:System;assembly=mscorlib"
+                 xmlns:cv="clr-namespace:Bonsai.Vision;assembly=Bonsai.Vision"
+                 xmlns="https://bonsai-rx.org/2018/workflow">
+  <Workflow>
+    <Nodes>
+      <Expression xsi:type="IncludeWorkflow" Path="UclOpen.Streaming:StreamController.bonsai">
+        <RigId>MyRig</RigId>
+        <SubjectId>Algernon</SubjectId>
+        <SessionId>001</SessionId>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="rx:Timer">
+          <rx:DueTime>PT0.5S</rx:DueTime>
+          <rx:Period>PT1S</rx:Period>
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="IntProperty">
+          <Value>42</Value>
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="IncludeWorkflow" Path="UclOpen.Streaming:PackDataMessage.bonsai">
+        <StreamName>data/first</StreamName>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="rx:Timer">
+          <rx:DueTime>PT0S</rx:DueTime>
+          <rx:Period>PT1S</rx:Period>
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="DoubleProperty">
+          <Value>142</Value>
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="IncludeWorkflow" Path="UclOpen.Streaming:PackDataMessage.bonsai">
+        <StreamName>data/second</StreamName>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="rx:Timer">
+          <rx:DueTime>PT0S</rx:DueTime>
+          <rx:Period>PT0.5S</rx:Period>
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="IncludeWorkflow" Path="UclOpen.Streaming:PackDataMessage.bonsai">
+        <StreamName>timer</StreamName>
+      </Expression>
+      <Expression xsi:type="IncludeWorkflow" Path="UclOpen.Streaming:ReceiveStream.bonsai">
+        <RigId>MyRig</RigId>
+        <StreamName>data</StreamName>
+        <ConnectionString>&gt;tcp://127.0.0.1:5556</ConnectionString>
+      </Expression>
+      <Expression xsi:type="rx:Condition">
+        <Workflow>
+          <Nodes>
+            <Expression xsi:type="WorkflowInput">
+              <Name>Source1</Name>
+            </Expression>
+            <Expression xsi:type="MemberSelector">
+              <Selector>Topic</Selector>
+            </Expression>
+            <Expression xsi:type="ExternalizedMapping">
+              <Property Name="Value" />
+            </Expression>
+            <Expression xsi:type="Equal">
+              <Operand xsi:type="StringProperty">
+                <Value>MyRig/data/first/</Value>
+              </Operand>
+            </Expression>
+            <Expression xsi:type="WorkflowOutput" />
+          </Nodes>
+          <Edges>
+            <Edge From="0" To="1" Label="Source1" />
+            <Edge From="1" To="3" Label="Source1" />
+            <Edge From="2" To="3" Label="Source2" />
+            <Edge From="3" To="4" Label="Source1" />
+          </Edges>
+        </Workflow>
+      </Expression>
+      <Expression xsi:type="p1:SelectStreamPayload">
+        <p1:Type xsi:type="TypeMapping" TypeArguments="sys:Int32" />
+      </Expression>
+      <Expression xsi:type="MemberSelector">
+        <Selector>Value</Selector>
+      </Expression>
+      <Expression xsi:type="MemberSelector">
+        <Selector>Index</Selector>
+      </Expression>
+      <Expression xsi:type="rx:Condition">
+        <Workflow>
+          <Nodes>
+            <Expression xsi:type="WorkflowInput">
+              <Name>Source1</Name>
+            </Expression>
+            <Expression xsi:type="MemberSelector">
+              <Selector>Topic</Selector>
+            </Expression>
+            <Expression xsi:type="ExternalizedMapping">
+              <Property Name="Value" />
+            </Expression>
+            <Expression xsi:type="Equal">
+              <Operand xsi:type="StringProperty">
+                <Value>MyRig/data/second/</Value>
+              </Operand>
+            </Expression>
+            <Expression xsi:type="WorkflowOutput" />
+          </Nodes>
+          <Edges>
+            <Edge From="0" To="1" Label="Source1" />
+            <Edge From="1" To="3" Label="Source1" />
+            <Edge From="2" To="3" Label="Source2" />
+            <Edge From="3" To="4" Label="Source1" />
+          </Edges>
+        </Workflow>
+      </Expression>
+      <Expression xsi:type="p1:SelectStreamPayload">
+        <p1:Type xsi:type="TypeMapping" TypeArguments="sys:Int32" />
+      </Expression>
+      <Expression xsi:type="MemberSelector">
+        <Selector>Value</Selector>
+      </Expression>
+      <Expression xsi:type="MemberSelector">
+        <Selector>Index</Selector>
+      </Expression>
+      <Expression xsi:type="IncludeWorkflow" Path="UclOpen.Streaming:ReceiveStream.bonsai">
+        <RigId>MyRig</RigId>
+        <StreamName>timer</StreamName>
+        <ConnectionString>&gt;tcp://127.0.0.1:5556</ConnectionString>
+      </Expression>
+      <Expression xsi:type="p1:SelectStreamPayload">
+        <p1:Type xsi:type="TypeMapping" TypeArguments="sys:Double" />
+      </Expression>
+      <Expression xsi:type="MemberSelector">
+        <Selector>Value</Selector>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="cv:CameraCapture">
+          <cv:Index>0</cv:Index>
+          <cv:CaptureProperties />
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="IncludeWorkflow" Path="UclOpen.Streaming:PackVideoMessage.bonsai">
+        <SampleInterval>PT0.2S</SampleInterval>
+        <FrameSize>
+          <Width>320</Width>
+          <Height>240</Height>
+        </FrameSize>
+        <Interpolation>Linear</Interpolation>
+        <StreamName>video</StreamName>
+      </Expression>
+      <Expression xsi:type="IncludeWorkflow" Path="UclOpen.Streaming:ReceiveVideo.bonsai">
+        <RigId>MyRig</RigId>
+        <StreamName>video</StreamName>
+        <ConnectionString>&gt;tcp://127.0.0.1:5558</ConnectionString>
+        <Mode>Unchanged</Mode>
+      </Expression>
+    </Nodes>
+    <Edges>
+      <Edge From="1" To="2" Label="Source1" />
+      <Edge From="2" To="3" Label="Source1" />
+      <Edge From="4" To="5" Label="Source1" />
+      <Edge From="5" To="6" Label="Source1" />
+      <Edge From="7" To="8" Label="Source1" />
+      <Edge From="9" To="10" Label="Source1" />
+      <Edge From="9" To="14" Label="Source1" />
+      <Edge From="10" To="11" Label="Source1" />
+      <Edge From="11" To="12" Label="Source1" />
+      <Edge From="11" To="13" Label="Source1" />
+      <Edge From="14" To="15" Label="Source1" />
+      <Edge From="15" To="16" Label="Source1" />
+      <Edge From="15" To="17" Label="Source1" />
+      <Edge From="18" To="19" Label="Source1" />
+      <Edge From="19" To="20" Label="Source1" />
+      <Edge From="21" To="22" Label="Source1" />
+    </Edges>
+  </Workflow>
+</WorkflowBuilder>

--- a/src/UclOpen.Streaming/BuildMessage.bonsai
+++ b/src/UclOpen.Streaming/BuildMessage.bonsai
@@ -1,0 +1,119 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<WorkflowBuilder Version="2.9.0"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xmlns:rx="clr-namespace:Bonsai.Reactive;assembly=Bonsai.Core"
+                 xmlns:zmq="clr-namespace:Bonsai.ZeroMQ;assembly=Bonsai.ZeroMQ"
+                 xmlns="https://bonsai-rx.org/2018/workflow">
+  <Workflow>
+    <Nodes>
+      <Expression xsi:type="WorkflowInput">
+        <Name>Source1</Name>
+      </Expression>
+      <Expression xsi:type="ExternalizedMapping">
+        <Property Name="StreamName" />
+        <Property Name="Encoding" />
+        <Property Name="PayloadType" />
+      </Expression>
+      <Expression xsi:type="rx:SelectMany">
+        <Name>BuildMessage</Name>
+        <Workflow>
+          <Nodes>
+            <Expression xsi:type="WorkflowInput">
+              <Name>Source1</Name>
+            </Expression>
+            <Expression xsi:type="rx:AsyncSubject">
+              <Name>Item</Name>
+            </Expression>
+            <Expression xsi:type="SubscribeSubject">
+              <Name>Item</Name>
+            </Expression>
+            <Expression xsi:type="SubscribeSubject">
+              <Name>StreamIdentity</Name>
+            </Expression>
+            <Expression xsi:type="Combinator">
+              <Combinator xsi:type="rx:Zip" />
+            </Expression>
+            <Expression xsi:type="ExternalizedMapping">
+              <Property Name="StreamName" />
+              <Property Name="Encoding" />
+              <Property Name="PayloadType" />
+            </Expression>
+            <Expression xsi:type="IncludeWorkflow" Path="UclOpen.Streaming:CreateEnvelope.bonsai">
+              <StreamName>data</StreamName>
+              <Encoding>json</Encoding>
+              <PayloadType>unknown</PayloadType>
+            </Expression>
+            <Expression xsi:type="Combinator">
+              <Combinator xsi:type="rx:Take">
+                <rx:Count>1</rx:Count>
+              </Combinator>
+            </Expression>
+            <Expression xsi:type="rx:AsyncSubject">
+              <Name>Envelope</Name>
+            </Expression>
+            <Expression xsi:type="SubscribeSubject">
+              <Name>Envelope</Name>
+            </Expression>
+            <Expression xsi:type="MemberSelector">
+              <Selector>Topic</Selector>
+            </Expression>
+            <Expression xsi:type="Combinator">
+              <Combinator xsi:type="zmq:ConvertToFrame" />
+            </Expression>
+            <Expression xsi:type="SubscribeSubject">
+              <Name>Envelope</Name>
+            </Expression>
+            <Expression xsi:type="MemberSelector">
+              <Selector>Header</Selector>
+            </Expression>
+            <Expression xsi:type="Combinator">
+              <Combinator xsi:type="zmq:ConvertToFrame" />
+            </Expression>
+            <Expression xsi:type="SubscribeSubject">
+              <Name>Item</Name>
+            </Expression>
+            <Expression xsi:type="MemberSelector">
+              <Selector>Value</Selector>
+            </Expression>
+            <Expression xsi:type="Combinator">
+              <Combinator xsi:type="zmq:ConvertToFrame" />
+            </Expression>
+            <Expression xsi:type="Combinator">
+              <Combinator xsi:type="rx:Concat" />
+            </Expression>
+            <Expression xsi:type="Combinator">
+              <Combinator xsi:type="zmq:ToMessage" />
+            </Expression>
+            <Expression xsi:type="WorkflowOutput" />
+          </Nodes>
+          <Edges>
+            <Edge From="0" To="1" Label="Source1" />
+            <Edge From="2" To="4" Label="Source1" />
+            <Edge From="3" To="4" Label="Source2" />
+            <Edge From="4" To="6" Label="Source1" />
+            <Edge From="5" To="6" Label="Source2" />
+            <Edge From="6" To="7" Label="Source1" />
+            <Edge From="7" To="8" Label="Source1" />
+            <Edge From="9" To="10" Label="Source1" />
+            <Edge From="10" To="11" Label="Source1" />
+            <Edge From="11" To="18" Label="Source1" />
+            <Edge From="12" To="13" Label="Source1" />
+            <Edge From="13" To="14" Label="Source1" />
+            <Edge From="14" To="18" Label="Source2" />
+            <Edge From="15" To="16" Label="Source1" />
+            <Edge From="16" To="17" Label="Source1" />
+            <Edge From="17" To="18" Label="Source3" />
+            <Edge From="18" To="19" Label="Source1" />
+            <Edge From="19" To="20" Label="Source1" />
+          </Edges>
+        </Workflow>
+      </Expression>
+      <Expression xsi:type="WorkflowOutput" />
+    </Nodes>
+    <Edges>
+      <Edge From="0" To="2" Label="Source1" />
+      <Edge From="1" To="2" Label="Source2" />
+      <Edge From="2" To="3" Label="Source1" />
+    </Edges>
+  </Workflow>
+</WorkflowBuilder>

--- a/src/UclOpen.Streaming/CreateEnvelope.bonsai
+++ b/src/UclOpen.Streaming/CreateEnvelope.bonsai
@@ -1,0 +1,98 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<WorkflowBuilder Version="2.9.0"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xmlns:rx="clr-namespace:Bonsai.Reactive;assembly=Bonsai.Core"
+                 xmlns:scr="clr-namespace:Bonsai.Scripting.Expressions;assembly=Bonsai.Scripting.Expressions"
+                 xmlns="https://bonsai-rx.org/2018/workflow">
+  <Workflow>
+    <Nodes>
+      <Expression xsi:type="WorkflowInput">
+        <Name>Source1</Name>
+      </Expression>
+      <Expression xsi:type="MemberSelector">
+        <Selector>Item2</Selector>
+      </Expression>
+      <Expression xsi:type="MemberSelector">
+        <Selector>Item1</Selector>
+      </Expression>
+      <Expression xsi:type="ExternalizedMapping">
+        <Property Name="Value" DisplayName="StreamName" Description="The logical stream name, used in both the topic and the header." />
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="StringProperty">
+          <Value>data</Value>
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="rx:Zip" />
+      </Expression>
+      <Expression xsi:type="Format">
+        <Format>{0}/{1}/</Format>
+        <Selector>Item1,Item2</Selector>
+      </Expression>
+      <Expression xsi:type="MemberSelector">
+        <Selector>Item2</Selector>
+      </Expression>
+      <Expression xsi:type="MemberSelector">
+        <Selector>Item1</Selector>
+      </Expression>
+      <Expression xsi:type="MemberSelector">
+        <Selector>Index</Selector>
+      </Expression>
+      <Expression xsi:type="ExternalizedMapping">
+        <Property Name="Value" DisplayName="Encoding" Description="How the payload frame is encoded: json, jpeg or raw." />
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="StringProperty">
+          <Value>json</Value>
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="rx:Zip" />
+      </Expression>
+      <Expression xsi:type="Format">
+        <Format>{{"rigId":"{0}","sessionKey":"{1}","stream":"{2}","index":{3},"enc":"{4}","type":"{5}"}}</Format>
+        <Selector>Item1,Item2,Item3,Item4,Item5,Item6</Selector>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="rx:Zip" />
+      </Expression>
+      <Expression xsi:type="scr:ExpressionTransform">
+        <scr:Expression>new( Item1 as Topic, Item2 as Header)</scr:Expression>
+      </Expression>
+      <Expression xsi:type="WorkflowOutput" />
+      <Expression xsi:type="ExternalizedMapping">
+        <Property Name="Value" DisplayName="PayloadType" Description="Name of the payload type, so a receiver knows what to deserialize into." />
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="StringProperty">
+          <Value>unknown</Value>
+        </Combinator>
+      </Expression>
+    </Nodes>
+    <Edges>
+      <Edge From="0" To="1" Label="Source1" />
+      <Edge From="0" To="8" Label="Source1" />
+      <Edge From="1" To="2" Label="Source1" />
+      <Edge From="1" To="7" Label="Source1" />
+      <Edge From="2" To="5" Label="Source1" />
+      <Edge From="2" To="12" Label="Source1" />
+      <Edge From="3" To="4" Label="Source1" />
+      <Edge From="4" To="5" Label="Source2" />
+      <Edge From="4" To="12" Label="Source3" />
+      <Edge From="5" To="6" Label="Source1" />
+      <Edge From="6" To="14" Label="Source1" />
+      <Edge From="7" To="12" Label="Source2" />
+      <Edge From="8" To="9" Label="Source1" />
+      <Edge From="9" To="12" Label="Source4" />
+      <Edge From="10" To="11" Label="Source1" />
+      <Edge From="11" To="12" Label="Source5" />
+      <Edge From="12" To="13" Label="Source1" />
+      <Edge From="13" To="14" Label="Source2" />
+      <Edge From="14" To="15" Label="Source1" />
+      <Edge From="15" To="16" Label="Source1" />
+      <Edge From="17" To="18" Label="Source1" />
+      <Edge From="18" To="12" Label="Source6" />
+    </Edges>
+  </Workflow>
+</WorkflowBuilder>

--- a/src/UclOpen.Streaming/PackDataMessage.bonsai
+++ b/src/UclOpen.Streaming/PackDataMessage.bonsai
@@ -1,0 +1,57 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<WorkflowBuilder Version="2.9.0"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xmlns:p1="clr-namespace:UclOpen.Streaming;assembly=UclOpen.Streaming"
+                 xmlns:rx="clr-namespace:Bonsai.Reactive;assembly=Bonsai.Core"
+                 xmlns="https://bonsai-rx.org/2018/workflow">
+  <Workflow>
+    <Nodes>
+      <Expression xsi:type="WorkflowInput">
+        <Name>Source1</Name>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="p1:SerializeStream">
+          <p1:Formatting>None</p1:Formatting>
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="MemberSelector">
+        <Selector>Json</Selector>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="rx:ElementIndex" />
+      </Expression>
+      <Expression xsi:type="MemberSelector">
+        <Selector>Type</Selector>
+      </Expression>
+      <Expression xsi:type="PropertyMapping">
+        <PropertyMappings>
+          <Property Name="PayloadType" Selector="it" />
+        </PropertyMappings>
+      </Expression>
+      <Expression xsi:type="ExternalizedMapping">
+        <Property Name="StreamName" />
+      </Expression>
+      <Expression xsi:type="IncludeWorkflow" Path="UclOpen.Streaming:BuildMessage.bonsai">
+        <StreamName>data</StreamName>
+        <Encoding>json</Encoding>
+        <PayloadType>unknown</PayloadType>
+      </Expression>
+      <Expression xsi:type="MulticastSubject">
+        <Name>DataMessage</Name>
+      </Expression>
+      <Expression xsi:type="WorkflowOutput" />
+    </Nodes>
+    <Edges>
+      <Edge From="0" To="1" Label="Source1" />
+      <Edge From="1" To="2" Label="Source1" />
+      <Edge From="1" To="4" Label="Source1" />
+      <Edge From="2" To="3" Label="Source1" />
+      <Edge From="3" To="7" Label="Source1" />
+      <Edge From="4" To="5" Label="Source1" />
+      <Edge From="5" To="7" Label="Source2" />
+      <Edge From="6" To="7" Label="Source3" />
+      <Edge From="7" To="8" Label="Source1" />
+      <Edge From="8" To="9" Label="Source1" />
+    </Edges>
+  </Workflow>
+</WorkflowBuilder>

--- a/src/UclOpen.Streaming/PackVideoMessage.bonsai
+++ b/src/UclOpen.Streaming/PackVideoMessage.bonsai
@@ -1,0 +1,75 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<WorkflowBuilder Version="2.9.0"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xmlns:rx="clr-namespace:Bonsai.Reactive;assembly=Bonsai.Core"
+                 xmlns:cv="clr-namespace:Bonsai.Vision;assembly=Bonsai.Vision"
+                 xmlns:dsp="clr-namespace:Bonsai.Dsp;assembly=Bonsai.Dsp"
+                 xmlns="https://bonsai-rx.org/2018/workflow">
+  <Workflow>
+    <Nodes>
+      <Expression xsi:type="WorkflowInput">
+        <Name>Source1</Name>
+      </Expression>
+      <Expression xsi:type="ExternalizedMapping">
+        <Property Name="Interval" DisplayName="SampleInterval" Description="How often to take a frame. Decimation in time, applied before any other work." />
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="rx:SampleInterval">
+          <rx:Interval>PT0.2S</rx:Interval>
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="ExternalizedMapping">
+        <Property Name="Size" DisplayName="FrameSize" Description="Size of the streamed frames. Decimation in space." />
+        <Property Name="Interpolation" DisplayName="Interpolation" />
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="cv:Resize">
+          <cv:Size>
+            <cv:Width>320</cv:Width>
+            <cv:Height>240</cv:Height>
+          </cv:Size>
+          <cv:Interpolation>Linear</cv:Interpolation>
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="cv:EncodeImage">
+          <cv:Extension>.jpg</cv:Extension>
+          <cv:CompressionParameters />
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="dsp:ConvertToArray">
+          <dsp:Depth xsi:nil="true" />
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="rx:ElementIndex" />
+      </Expression>
+      <Expression xsi:type="ExternalizedMapping">
+        <Property Name="StreamName" />
+      </Expression>
+      <Expression xsi:type="IncludeWorkflow" Path="UclOpen.Streaming:BuildMessage.bonsai">
+        <StreamName>video</StreamName>
+        <Encoding>jpeg</Encoding>
+        <PayloadType>Image</PayloadType>
+      </Expression>
+      <Expression xsi:type="MulticastSubject">
+        <Name>VideoMessage</Name>
+      </Expression>
+      <Expression xsi:type="WorkflowOutput" />
+    </Nodes>
+    <Edges>
+      <Edge From="0" To="2" Label="Source1" />
+      <Edge From="1" To="2" Label="Source2" />
+      <Edge From="2" To="4" Label="Source1" />
+      <Edge From="3" To="4" Label="Source2" />
+      <Edge From="4" To="5" Label="Source1" />
+      <Edge From="5" To="6" Label="Source1" />
+      <Edge From="6" To="7" Label="Source1" />
+      <Edge From="7" To="9" Label="Source1" />
+      <Edge From="8" To="9" Label="Source2" />
+      <Edge From="9" To="10" Label="Source1" />
+      <Edge From="10" To="11" Label="Source1" />
+    </Edges>
+  </Workflow>
+</WorkflowBuilder>

--- a/src/UclOpen.Streaming/ParseStreamMessage.cs
+++ b/src/UclOpen.Streaming/ParseStreamMessage.cs
@@ -1,0 +1,61 @@
+using System;
+using System.ComponentModel;
+using System.Reactive.Linq;
+using Bonsai;
+using NetMQ;
+using Newtonsoft.Json;
+
+namespace UclOpen.Streaming
+{
+    /// <summary>
+    /// Represents an operator that unpacks a received multipart message into its topic, header
+    /// and payload. Messages with an unreadable header are marked invalid and passed through
+    /// rather than terminating the sequence.
+    /// </summary>
+    [Combinator]
+    [Description("Unpacks a received multipart message into its topic, header and payload.")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    public class ParseStreamMessage
+    {
+        /// <summary>
+        /// Unpacks each multipart message in an observable sequence.
+        /// </summary>
+        /// <param name="source">The sequence of received multipart messages.</param>
+        /// <returns>A sequence of unpacked messages.</returns>
+        public IObservable<StreamMessage> Process(IObservable<NetMQMessage> source)
+        {
+            return source.Select(message =>
+            {
+                var result = new StreamMessage { Header = new StreamHeader(), Payload = new byte[0] };
+                if (message.FrameCount > 0)
+                {
+                    result.Topic = message[0].ConvertToString();
+                }
+
+                if (message.FrameCount > 2)
+                {
+                    result.Payload = message[2].ToByteArray();
+                }
+
+                if (message.FrameCount > 1)
+                {
+                    try
+                    {
+                        var header = JsonConvert.DeserializeObject<StreamHeader>(message[1].ConvertToString());
+                        if (header != null)
+                        {
+                            result.Header = header;
+                            result.Valid = true;
+                        }
+                    }
+                    catch (JsonException)
+                    {
+                        result.Valid = false;
+                    }
+                }
+
+                return result;
+            });
+        }
+    }
+}

--- a/src/UclOpen.Streaming/Properties/AssemblyInfo.cs
+++ b/src/UclOpen.Streaming/Properties/AssemblyInfo.cs
@@ -1,0 +1,6 @@
+using Bonsai;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: XmlNamespacePrefix("clr-namespace:UclOpen.Streaming", null)]

--- a/src/UclOpen.Streaming/README.md
+++ b/src/UclOpen.Streaming/README.md
@@ -1,0 +1,33 @@
+# UclOpen.Streaming
+
+Bonsai operators to stream live experiment telemetry over ZeroMQ, and receive it on a remote machine. A rig publishes values, images and events as they happen; a machine elsewhere on the same network subscribes to the
+named stream and returns them in their original types.
+
+## Operators
+
+| Operator | Role |
+|----------|------|
+| `StreamController` | Opens the sockets, declares data and video `Subjects` and defines and publishes rig/session identity. |
+| `PackDataMessage` | Serializes a value and packs it into a message with Topic, JSON header and payload. |
+| `PackVideoMessage` | Decimates, resizes, encodes and packs video frames into ZeroMQ messages. |
+| `ReceiveStream` | Subscribes to a named stream and unpacks to a `StreamMessage`. |
+| `SelectStreamPayload` | Deserializes the payload into `SessionKey`, `Index` and `Value`. |
+| `ReceiveVideo` | As `ReceiveStream`, but decodes frames to an image. |
+
+## Getting started
+
+Put a `StreamController` at the top of a workflow and set its `RigId`. Send any value over the network by adding a `PackDataMessage` with a `StreamName` property.
+
+On the receiving machine, subscribe to a stream by adding a `ReceiveStream` node with the correct name.
+
+`SelectStreamPayload` parses each message to `SessionKey`, `Index` and `Value`, where `Value` has the type the publisher sent rather than a JSON string. `Index` increments per stream, so gaps can be used to determine if messages were dropped.
+
+Message format is ZeroMQ and JSON, so a consumer need not be Bonsai. Any language with a ZeroMQ binding — Python, for example — can subscribe by topic prefix.
+
+## Dependencies
+
+Installed with the package: `Bonsai.Core`, `Bonsai.Dsp`, `Bonsai.Scripting.Expressions`, `Bonsai.Vision`, `Bonsai.ZeroMQ`, `NetMQ`, `Newtonsoft.Json`, `UclOpen.Core`.
+
+## Documentation
+
+<https://ucl-open.github.io/ucl-open/bonsai-operators/UclOpen.Streaming/streaming.html>

--- a/src/UclOpen.Streaming/ReceiveStream.bonsai
+++ b/src/UclOpen.Streaming/ReceiveStream.bonsai
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8"?>
+<WorkflowBuilder Version="2.9.0"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xmlns:rx="clr-namespace:Bonsai.Reactive;assembly=Bonsai.Core"
+                 xmlns:p1="clr-namespace:UclOpen.Streaming;assembly=UclOpen.Streaming"
+                 xmlns:zmq="clr-namespace:Bonsai.ZeroMQ;assembly=Bonsai.ZeroMQ"
+                 xmlns="https://bonsai-rx.org/2018/workflow">
+  <Workflow>
+    <Nodes>
+      <Expression xsi:type="ExternalizedMapping">
+        <Property Name="Value" DisplayName="RigId" Description="Identifier of the rig to subscribe to. Must match the publisher's RigId." />
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="StringProperty">
+          <Value>MyRig</Value>
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="ExternalizedMapping">
+        <Property Name="Value" DisplayName="StreamName" Description="Stream to subscribe to. Must match the publisher's StreamName." />
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="StringProperty">
+          <Value>data</Value>
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="rx:Zip" />
+      </Expression>
+      <Expression xsi:type="Format">
+        <Format>{0}/{1}/</Format>
+        <Selector>Item1,Item2</Selector>
+      </Expression>
+      <Expression xsi:type="PropertyMapping">
+        <PropertyMappings>
+          <Property Name="Topic" />
+        </PropertyMappings>
+      </Expression>
+      <Expression xsi:type="ExternalizedMapping">
+        <Property Name="ConnectionString" DisplayName="ConnectionString" Description="Publisher endpoint to connect to, for example &gt;tcp://rig-machine:5556" />
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="zmq:Subscriber">
+          <zmq:ConnectionString>&gt;tcp://127.0.0.1:5556</zmq:ConnectionString>
+          <zmq:Topic></zmq:Topic>
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="p1:ParseStreamMessage" />
+      </Expression>
+      <Expression xsi:type="WorkflowOutput" />
+    </Nodes>
+    <Edges>
+      <Edge From="0" To="1" Label="Source1" />
+      <Edge From="2" To="3" Label="Source1" />
+      <Edge From="1" To="4" Label="Source1" />
+      <Edge From="3" To="4" Label="Source2" />
+      <Edge From="4" To="5" Label="Source1" />
+      <Edge From="5" To="6" Label="Source1" />
+      <Edge From="6" To="8" Label="Source1" />
+      <Edge From="7" To="8" Label="Source2" />
+      <Edge From="8" To="9" Label="Source1" />
+      <Edge From="9" To="10" Label="Source1" />
+    </Edges>
+  </Workflow>
+</WorkflowBuilder>

--- a/src/UclOpen.Streaming/ReceiveVideo.bonsai
+++ b/src/UclOpen.Streaming/ReceiveVideo.bonsai
@@ -1,0 +1,100 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<WorkflowBuilder Version="2.9.1"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xmlns:rx="clr-namespace:Bonsai.Reactive;assembly=Bonsai.Core"
+                 xmlns:zmq="clr-namespace:Bonsai.ZeroMQ;assembly=Bonsai.ZeroMQ"
+                 xmlns:p1="clr-namespace:UclOpen.Streaming;assembly=UclOpen.Streaming"
+                 xmlns:cv="clr-namespace:Bonsai.Vision;assembly=Bonsai.Vision"
+                 xmlns:scr="clr-namespace:Bonsai.Scripting.Expressions;assembly=Bonsai.Scripting.Expressions"
+                 xmlns="https://bonsai-rx.org/2018/workflow">
+  <Workflow>
+    <Nodes>
+      <Expression xsi:type="ExternalizedMapping">
+        <Property Name="Value" DisplayName="RigId" Description="Identifier of the rig to subscribe to. Must match the publisher's RigId." />
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="StringProperty">
+          <Value>MyRig</Value>
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="ExternalizedMapping">
+        <Property Name="Value" DisplayName="StreamName" Description="Video stream to subscribe to. Must match the publisher's StreamName." />
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="StringProperty">
+          <Value>video</Value>
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="rx:Zip" />
+      </Expression>
+      <Expression xsi:type="Format">
+        <Format>{0}/{1}/</Format>
+        <Selector>Item1,Item2</Selector>
+      </Expression>
+      <Expression xsi:type="PropertyMapping">
+        <PropertyMappings>
+          <Property Name="Topic" />
+        </PropertyMappings>
+      </Expression>
+      <Expression xsi:type="ExternalizedMapping">
+        <Property Name="ConnectionString" DisplayName="ConnectionString" Description="Publisher endpoint to connect to, for example &gt;tcp://rig-machine:5558" />
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="zmq:Subscriber">
+          <zmq:ConnectionString>&gt;tcp://127.0.0.1:5558</zmq:ConnectionString>
+          <zmq:Topic></zmq:Topic>
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="p1:ParseStreamMessage" />
+      </Expression>
+      <Expression xsi:type="rx:PublishSubject">
+        <Name>Message</Name>
+      </Expression>
+      <Expression xsi:type="SubscribeSubject">
+        <Name>Message</Name>
+      </Expression>
+      <Expression xsi:type="MemberSelector">
+        <Selector>Payload</Selector>
+      </Expression>
+      <Expression xsi:type="ExternalizedMapping">
+        <Property Name="Mode" DisplayName="Mode" Description="Optional conversion applied to the decoded image, for example grayscale." />
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="cv:DecodeImage">
+          <cv:Mode>Unchanged</cv:Mode>
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="SubscribeSubject">
+        <Name>Message</Name>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="rx:Zip" />
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="p1:SelectStreamValue" />
+      </Expression>
+      <Expression xsi:type="WorkflowOutput" />
+    </Nodes>
+    <Edges>
+      <Edge From="0" To="1" Label="Source1" />
+      <Edge From="1" To="4" Label="Source1" />
+      <Edge From="2" To="3" Label="Source1" />
+      <Edge From="3" To="4" Label="Source2" />
+      <Edge From="4" To="5" Label="Source1" />
+      <Edge From="5" To="6" Label="Source1" />
+      <Edge From="6" To="8" Label="Source1" />
+      <Edge From="7" To="8" Label="Source2" />
+      <Edge From="8" To="9" Label="Source1" />
+      <Edge From="9" To="10" Label="Source1" />
+      <Edge From="11" To="12" Label="Source1" />
+      <Edge From="12" To="14" Label="Source1" />
+      <Edge From="13" To="14" Label="Source2" />
+      <Edge From="14" To="16" Label="Source1" />
+      <Edge From="15" To="16" Label="Source2" />
+      <Edge From="16" To="17" Label="Source1" />
+      <Edge From="17" To="18" Label="Source1" />
+    </Edges>
+  </Workflow>
+</WorkflowBuilder>

--- a/src/UclOpen.Streaming/SelectStreamPayload.cs
+++ b/src/UclOpen.Streaming/SelectStreamPayload.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reactive.Linq;
+using System.Xml.Serialization;
+using Bonsai;
+using Bonsai.Expressions;
+using Newtonsoft.Json;
+using UclOpen.Core.DataTypes;
+
+namespace UclOpen.Streaming
+{
+    /// <summary>
+    /// Represents a received payload, reduced to the fields that vary from message to message.
+    /// </summary>
+    /// <typeparam name="T">The type the payload was serialized from.</typeparam>
+    public class StreamPayload<T>
+    {
+        /// <summary>
+        /// Gets or sets the session the message belongs to. It changes when a new session starts.
+        /// </summary>
+        public string SessionKey { get; set; }
+
+        /// <summary>
+        /// Gets or sets the per-stream message index. A gap indicates dropped messages.
+        /// </summary>
+        public long Index { get; set; }
+
+        /// <summary>
+        /// Gets or sets the deserialized payload.
+        /// </summary>
+        public T Value { get; set; }
+    }
+
+    /// <summary>
+    /// Represents an operator that deserializes the payload of each received message into the
+    /// specified type, keeping only the session key and message index. Messages whose header
+    /// could not be parsed are dropped.
+    /// </summary>
+    /// <remarks>
+    /// The selectable types are the XmlInclude attributes below, and the list is maintained by
+    /// hand. Add an entry to stream a type that is not yet listed; without one the workflow
+    /// cannot store the choice. Vector2 and Vector3 show the pattern for schema types from
+    /// UclOpen.Core.
+    /// </remarks>
+    [DefaultProperty("Type")]
+    [Description("Deserializes the payload of each received message into the specified type.")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    [XmlInclude(typeof(TypeMapping<string>))]
+    [XmlInclude(typeof(TypeMapping<bool>))]
+    [XmlInclude(typeof(TypeMapping<int>))]
+    [XmlInclude(typeof(TypeMapping<long>))]
+    [XmlInclude(typeof(TypeMapping<float>))]
+    [XmlInclude(typeof(TypeMapping<double>))]
+    [XmlInclude(typeof(TypeMapping<Vector2>))]
+    [XmlInclude(typeof(TypeMapping<Vector3>))]
+    public class SelectStreamPayload : SingleArgumentExpressionBuilder
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SelectStreamPayload"/> class.
+        /// </summary>
+        public SelectStreamPayload()
+        {
+            Type = new TypeMapping<string>();
+        }
+
+        /// <summary>
+        /// Gets or sets the type the payload will be deserialized into. It must match the type
+        /// the publisher serialized, which is reported in the message header.
+        /// </summary>
+        public TypeMapping Type { get; set; }
+
+        /// <inheritdoc/>
+        public override Expression Build(IEnumerable<Expression> arguments)
+        {
+            var typeMapping = (TypeMapping)Type;
+            var returnType = typeMapping.GetType().GetGenericArguments()[0];
+            return Expression.Call(
+                typeof(SelectStreamPayload),
+                "Process",
+                new[] { returnType },
+                Enumerable.Single(arguments));
+        }
+
+        private static IObservable<StreamPayload<T>> Process<T>(IObservable<StreamMessage> source)
+        {
+            return source.Where(message => message.Valid).Select(message => new StreamPayload<T>
+            {
+                SessionKey = message.Header.SessionKey,
+                Index = message.Header.Index,
+                Value = JsonConvert.DeserializeObject<T>(message.Text)
+            });
+        }
+    }
+}

--- a/src/UclOpen.Streaming/SelectStreamValue.cs
+++ b/src/UclOpen.Streaming/SelectStreamValue.cs
@@ -1,0 +1,35 @@
+using System;
+using System.ComponentModel;
+using System.Reactive.Linq;
+using Bonsai;
+
+namespace UclOpen.Streaming
+{
+    /// <summary>
+    /// Represents an operator that attaches the session key and message index of a received
+    /// message to a value derived from it, producing the same shape as
+    /// <see cref="SelectStreamPayload"/>. Use where the payload is decoded by a dedicated
+    /// operator rather than deserialized, such as an image.
+    /// </summary>
+    [Combinator]
+    [Description("Attaches the session key and message index of a received message to a value derived from it.")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    public class SelectStreamValue
+    {
+        /// <summary>
+        /// Attaches message identity to each decoded value in an observable sequence.
+        /// </summary>
+        /// <typeparam name="TValue">The type of the decoded value.</typeparam>
+        /// <param name="source">A sequence pairing each decoded value with the message it came from.</param>
+        /// <returns>A sequence of payloads carrying the session key, message index and value.</returns>
+        public IObservable<StreamPayload<TValue>> Process<TValue>(IObservable<Tuple<TValue, StreamMessage>> source)
+        {
+            return source.Select(pair => new StreamPayload<TValue>
+            {
+                SessionKey = pair.Item2.Header.SessionKey,
+                Index = pair.Item2.Header.Index,
+                Value = pair.Item1
+            });
+        }
+    }
+}

--- a/src/UclOpen.Streaming/SerializeStream.cs
+++ b/src/UclOpen.Streaming/SerializeStream.cs
@@ -1,0 +1,56 @@
+using System;
+using System.ComponentModel;
+using System.Reactive.Linq;
+using Bonsai;
+using Newtonsoft.Json;
+
+namespace UclOpen.Streaming
+{
+    /// <summary>
+    /// Represents a payload serialized to JSON, together with the name of the type it came from.
+    /// </summary>
+    public class SerializedPayload
+    {
+        /// <summary>
+        /// Gets or sets the name of the type the payload was serialized from.
+        /// </summary>
+        public string Type { get; set; }
+
+        /// <summary>
+        /// Gets or sets the payload serialized as JSON.
+        /// </summary>
+        public string Json { get; set; }
+    }
+
+    /// <summary>
+    /// Represents an operator that serializes any value to JSON for streaming and tags it with
+    /// its runtime type name.
+    /// </summary>
+    [Combinator]
+    [Description("Serializes any value to JSON for streaming and tags it with its runtime type name.")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    public class SerializeStream
+    {
+        /// <summary>
+        /// Gets or sets the formatting applied to the serialized output.
+        /// </summary>
+        [Description("The formatting applied to the serialized output.")]
+        public Formatting Formatting { get; set; }
+
+        /// <summary>
+        /// Serializes each value in an observable sequence to JSON.
+        /// </summary>
+        /// <typeparam name="TSource">The type of the elements to serialize.</typeparam>
+        /// <param name="source">The sequence of values to serialize.</param>
+        /// <returns>A sequence of serialized payloads.</returns>
+        public IObservable<SerializedPayload> Process<TSource>(IObservable<TSource> source)
+        {
+            var formatting = Formatting;
+            return source.Select(value => new SerializedPayload
+            {
+                Type = value == null ? typeof(TSource).Name : value.GetType().Name,
+                Json = JsonConvert.SerializeObject(value, formatting)
+            });
+        }
+    }
+}

--- a/src/UclOpen.Streaming/StreamController.bonsai
+++ b/src/UclOpen.Streaming/StreamController.bonsai
@@ -1,0 +1,116 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<WorkflowBuilder Version="2.9.0"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xmlns:rx="clr-namespace:Bonsai.Reactive;assembly=Bonsai.Core"
+                 xmlns:p1="clr-namespace:UclOpen.Core;assembly=UclOpen.Core"
+                 xmlns:p2="clr-namespace:NetMQ;assembly=NetMQ"
+                 xmlns:zmq="clr-namespace:Bonsai.ZeroMQ;assembly=Bonsai.ZeroMQ"
+                 xmlns="https://bonsai-rx.org/2018/workflow">
+  <Workflow>
+    <Nodes>
+      <Expression xsi:type="ExternalizedMapping">
+        <Property Name="Value" DisplayName="RigId" Description="The rig identifier included in every published topic." />
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="StringProperty">
+          <Value>MyRig</Value>
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="rx:Timestamp" />
+      </Expression>
+      <Expression xsi:type="MemberSelector">
+        <Selector>Value</Selector>
+      </Expression>
+      <Expression xsi:type="ExternalizedMapping">
+        <Property Name="Value" DisplayName="SubjectId" Description="The subject identifier, matching the logging session directory." />
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="StringProperty">
+          <Value>Algernon</Value>
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="ExternalizedMapping">
+        <Property Name="Value" DisplayName="SessionId" Description="The session identifier, matching the logging session directory." />
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="StringProperty">
+          <Value>001</Value>
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="MemberSelector">
+        <Selector>Timestamp.UtcDateTime</Selector>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="p1:FormatDate" />
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="rx:Zip" />
+      </Expression>
+      <Expression xsi:type="Format">
+        <Format>sub-{0}/ses-{1}_date-{2}</Format>
+        <Selector>Item1,Item2,Item3</Selector>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="rx:Zip" />
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="rx:Take">
+          <rx:Count>1</rx:Count>
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="rx:AsyncSubject">
+        <Name>StreamIdentity</Name>
+      </Expression>
+      <Expression xsi:type="rx:PublishSubject" TypeArguments="p2:NetMQMessage">
+        <rx:Name>DataMessage</rx:Name>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="rx:ObserveOn">
+          <rx:Scheduler>NewThreadScheduler</rx:Scheduler>
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="zmq:Publisher">
+          <zmq:ConnectionString>@tcp://0.0.0.0:5556</zmq:ConnectionString>
+          <zmq:Topic />
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="rx:PublishSubject" TypeArguments="p2:NetMQMessage">
+        <rx:Name>VideoMessage</rx:Name>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="rx:ObserveOn">
+          <rx:Scheduler>NewThreadScheduler</rx:Scheduler>
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="zmq:Publisher">
+          <zmq:ConnectionString>@tcp://0.0.0.0:5558</zmq:ConnectionString>
+          <zmq:Topic />
+        </Combinator>
+      </Expression>
+    </Nodes>
+    <Edges>
+      <Edge From="0" To="1" Label="Source1" />
+      <Edge From="1" To="2" Label="Source1" />
+      <Edge From="2" To="3" Label="Source1" />
+      <Edge From="2" To="8" Label="Source1" />
+      <Edge From="3" To="12" Label="Source1" />
+      <Edge From="4" To="5" Label="Source1" />
+      <Edge From="5" To="10" Label="Source1" />
+      <Edge From="6" To="7" Label="Source1" />
+      <Edge From="7" To="10" Label="Source2" />
+      <Edge From="8" To="9" Label="Source1" />
+      <Edge From="9" To="10" Label="Source3" />
+      <Edge From="10" To="11" Label="Source1" />
+      <Edge From="11" To="12" Label="Source2" />
+      <Edge From="12" To="13" Label="Source1" />
+      <Edge From="13" To="14" Label="Source1" />
+      <Edge From="15" To="16" Label="Source1" />
+      <Edge From="16" To="17" Label="Source1" />
+      <Edge From="18" To="19" Label="Source1" />
+      <Edge From="19" To="20" Label="Source1" />
+    </Edges>
+  </Workflow>
+</WorkflowBuilder>

--- a/src/UclOpen.Streaming/StreamMessage.cs
+++ b/src/UclOpen.Streaming/StreamMessage.cs
@@ -1,0 +1,80 @@
+using Newtonsoft.Json;
+
+namespace UclOpen.Streaming
+{
+    /// <summary>
+    /// Represents the header carried in the second frame of a streamed message.
+    /// </summary>
+    public class StreamHeader
+    {
+        /// <summary>
+        /// Gets or sets the identifier of the rig that published the message.
+        /// </summary>
+        [JsonProperty("rigId")]
+        public string RigId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the session key, matching the logging session directory.
+        /// </summary>
+        [JsonProperty("sessionKey")]
+        public string SessionKey { get; set; }
+
+        /// <summary>
+        /// Gets or sets the logical stream name.
+        /// </summary>
+        [JsonProperty("stream")]
+        public string Stream { get; set; }
+
+        /// <summary>
+        /// Gets or sets the per-stream message index. A gap indicates dropped messages.
+        /// </summary>
+        [JsonProperty("index")]
+        public long Index { get; set; }
+
+        /// <summary>
+        /// Gets or sets how the payload frame is encoded: json, jpeg or raw.
+        /// </summary>
+        [JsonProperty("enc")]
+        public string Encoding { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name of the payload type, used to select a deserializer.
+        /// </summary>
+        [JsonProperty("type")]
+        public string Type { get; set; }
+    }
+
+    /// <summary>
+    /// Represents a received message, unpacked into its topic, header and payload.
+    /// </summary>
+    public class StreamMessage
+    {
+        /// <summary>
+        /// Gets or sets the topic from the first frame.
+        /// </summary>
+        public string Topic { get; set; }
+
+        /// <summary>
+        /// Gets or sets the parsed header from the second frame.
+        /// </summary>
+        public StreamHeader Header { get; set; }
+
+        /// <summary>
+        /// Gets or sets the raw payload bytes from the third frame.
+        /// </summary>
+        public byte[] Payload { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the header parsed successfully.
+        /// </summary>
+        public bool Valid { get; set; }
+
+        /// <summary>
+        /// Gets the payload decoded as UTF-8 text.
+        /// </summary>
+        public string Text
+        {
+            get { return Payload == null ? string.Empty : System.Text.Encoding.UTF8.GetString(Payload); }
+        }
+    }
+}

--- a/src/UclOpen.Streaming/UclOpen.Streaming.csproj
+++ b/src/UclOpen.Streaming/UclOpen.Streaming.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <Description>UclOpen Streaming Bonsai library. Streams live experiment telemetry over ZeroMQ, and receives it on a remote machine.</Description>
+    <PackageTags>$(PackageTags) Streaming</PackageTags>
+    <TargetFrameworks>net472</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="**\*.bonsai" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Bonsai.Core" Version="2.9.0" />
+    <PackageReference Include="Bonsai.ZeroMQ" Version="0.2.0" />
+    <PackageReference Include="NetMQ" Version="4.0.1.12" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\UclOpen.Core\UclOpen.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/UclOpen.Streaming/UclOpen.Streaming.csproj
+++ b/src/UclOpen.Streaming/UclOpen.Streaming.csproj
@@ -12,6 +12,9 @@
 
   <ItemGroup>
     <PackageReference Include="Bonsai.Core" Version="2.9.0" />
+    <PackageReference Include="Bonsai.Dsp" Version="2.9.0" />
+    <PackageReference Include="Bonsai.Scripting.Expressions" Version="2.10.0" />
+    <PackageReference Include="Bonsai.Vision" Version="2.9.0" />
     <PackageReference Include="Bonsai.ZeroMQ" Version="0.2.0" />
     <PackageReference Include="NetMQ" Version="4.0.1.12" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />


### PR DESCRIPTION
Adds `UclOpen.Streaming`, a Bonsai package for streaming live experiment telemetry over ZeroMQ and receiving it on a remote machine. This allows remote monitoring and moving sometimes heavy GUIs off the acquisition machine. The transport is lossy: a publisher drops messages rather than blocking when a subscriber cannot keep up, so a slow viewer does not hold up acquisition, but also means streamed data should not be logged or used for analysis. 

## Operators

| Operator | Role |
|----------|------|
| `StreamController` | Opens the sockets, publishes rig/session identity |
| `PackDataMessage` | Serializes a value and packs it into a message. One per data stream |
| `PackVideoMessage` | Decimates, resizes and JPEG-encodes frames, then packs them. One per camera |
| `ReceiveStream` | Subscribes to a named stream and unpacks to a `StreamMessage` |
| `SelectStreamPayload` | Deserializes the payload into `SessionKey`, `Index` and `Value` |
| `ReceiveVideo` | As `ReceiveStream`, but decodes frames to an image |

Data and video frames are packed into three frames per message: topic, JSON header, payload. 

Docs are included, including example workflows to demonstrate it's use. Note also that a subscribing machine can also publish, so one can also send commands to the acquisition machine. 

## Testing

Example workflows in the docs were tested, with multiple streams of data and video verified working across the network in Coen lab, hitting no firewall restrictions. 